### PR TITLE
Shopify OAuth handler

### DIFF
--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Configuration/AppSettings.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Configuration/AppSettings.cs
@@ -8,6 +8,8 @@
 
         public string SemrushClientSecret { get; set; }
 
+        public string ShopifyClientSecret { get; set; }
+
         public string this[string propertyName] => (string)GetType().GetProperty(propertyName)?.GetValue(this, null);
     }
 }

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/OAuthProxyController.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/OAuthProxyController.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Security;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Integrations.OAuthProxy.Configuration;
 
 namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
@@ -18,13 +20,14 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
         private readonly AppSettings _appSettings;
 
         public const string ServiceNameHeaderKey = "service_name";
+        public const string ServiceAddressReplacePrefixHeaderKey = "service_address_";
 
         /// <summary>
         /// Integrated services with their token URIs
         /// </summary>
-        private static Dictionary<string, string> ValidServices = new()
+        private static readonly Dictionary<string, string> ValidServices = new()
         {
-            { "Hubspot", "oauth/v1/token" }, { "HubspotForms", "oauth/v1/token" }, { "Semrush", "oauth2/access_token" }
+            { "Hubspot", "oauth/v1/token" }, { "HubspotForms", "oauth/v1/token" }, { "Semrush", "oauth2/access_token" }, { "Shopify", "oauth/access_token" }
         };
 
         public OAuthProxyController(IHttpClientFactory httpClientFactory, IOptions<AppSettings> appSettings)
@@ -48,7 +51,7 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
                     new InvalidOperationException($"Provided {ServiceNameHeaderKey} header value of {serviceName} is not supported");
             }
 
-            var httpClient = _httpClientFactory.CreateClient($"{serviceName}Token");
+            var httpClient = GetClient(serviceName);
 
             var response =
                 await httpClient.PostAsync(ValidServices[serviceName], GetContent(Request.Form, serviceName));
@@ -60,6 +63,22 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
             Response.ContentLength = response.Content.Headers.ContentLength;
 
             await Response.WriteAsync(content);
+        }
+
+        private HttpClient GetClient(string serviceName)
+        {
+            var httpClient = _httpClientFactory.CreateClient($"{serviceName}Token");
+
+            var serviceAddressReplaceHeader = Request.Headers.FirstOrDefault(p => p.Key.Contains(ServiceAddressReplacePrefixHeaderKey));
+            if (!serviceAddressReplaceHeader.Equals(default(KeyValuePair<string, StringValues>)) && httpClient.BaseAddress != null)
+            {
+                var replaceKey = serviceAddressReplaceHeader.Key.Replace(ServiceAddressReplacePrefixHeaderKey, string.Empty);
+
+                var baseAddress = httpClient.BaseAddress.ToString().Replace($"{replaceKey}", serviceAddressReplaceHeader.Value);
+                httpClient.BaseAddress = new Uri(baseAddress);
+            }
+
+            return httpClient;
         }
 
         private HttpContent GetContent(IFormCollection form, string serviceName)

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/OAuthProxyController.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/OAuthProxyController.cs
@@ -69,6 +69,8 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
         {
             var httpClient = _httpClientFactory.CreateClient($"{serviceName}Token");
 
+            // Shopify's endpoint (and potentially others in future) for retrieving the access token is directly coupled with the shop's name.
+            // As a result the address of the client needs to be updated with the request header value for the name of the shop.
             var serviceAddressReplaceHeader = Request.Headers.FirstOrDefault(p => p.Key.Contains(ServiceAddressReplacePrefixHeaderKey));
             if (!serviceAddressReplaceHeader.Equals(default(KeyValuePair<string, StringValues>)) && httpClient.BaseAddress != null)
             {

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Pages/Shopify.cshtml
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Pages/Shopify.cshtml
@@ -1,0 +1,37 @@
+﻿@page "/oauth/shopify"
+@model Umbraco.Cms.Integrations.OAuthProxy.Pages.ShopifyModel
+@{
+    ViewData["Title"] = "Authorization";
+}
+
+<div class="text-center">
+    <h1 class="display-4">Umbraco Integrations Authentication</h1>
+    @if (!string.IsNullOrEmpty(Model.AuthorizationCode))
+    {
+        <div id="manual-complete" style="display: none">
+            <p>To complete the integration, please copy the following code and enter it in Umbraco using the form provided.</p>
+
+            <p><input id="auth-code" type="text" value="@Model.AuthorizationCode" readonly style="width: 700px; font-size: 36px; text-align: center" /></p>
+
+            <button onclick="copyToClipboard()">Copy To Clipboard</button>
+        </div>
+
+        <script>
+            if (window.opener && typeof opener.postMessage === 'function') {
+                opener.postMessage({ type: 'shopify:oauth:success', url: location.href, code: '@Model.AuthorizationCode' }, '*');
+                window.close();
+            } else {
+                document.getElementById("manual-complete").style.display = "block";
+            }1
+
+            function copyToClipboard() {
+                var authCodeInputElement = document.getElementById("auth-code");
+                authCodeInputElement.select();
+                authCodeInputElement.setSelectionRange(0, 99999);
+                navigator.clipboard.writeText(authCodeInputElement.value);
+                alert("Code copied to clipboard");
+            }
+        </script>
+
+    }
+</div>

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Pages/Shopify.cshtml.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Pages/Shopify.cshtml.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Umbraco.Cms.Integrations.OAuthProxy.Pages
+{
+    public class ShopifyModel : PageModel
+    {
+        public string AuthorizationCode { get; set; }
+
+        public void OnGet()
+        {
+            AuthorizationCode = Request.Query["code"];
+        }
+    }
+}

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Startup.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+
 using Umbraco.Cms.Integrations.OAuthProxy.Configuration;
 
 namespace Umbraco.Cms.Integrations.OAuthProxy
@@ -34,6 +35,10 @@ namespace Umbraco.Cms.Integrations.OAuthProxy
             services.AddHttpClient("SemrushToken", c =>
             {
                 c.BaseAddress = new Uri("https://oauth.semrush.com/");
+            });
+            services.AddHttpClient("ShopifyToken", c =>
+            {
+                c.BaseAddress = new Uri("https://shop-replace.myshopify.com/admin/");
             });
 
             services.AddRazorPages();

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/appsettings.Development.json
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/appsettings.Development.json
@@ -10,6 +10,7 @@
   "AppSettings": {
     "HubspotClientSecret": "",
     "HubspotFormsClientSecret": "",
-    "SemrushClientSecret": ""
+    "SemrushClientSecret": "",
+    "ShopifyClientSecret":  "" 
   }
 }


### PR DESCRIPTION
- New razor page to handle Shopify oauth success operation
- Shopify's endpoint for retrieving the access token is directly coupled with the shop's name; as a result the address of the client will be updated with the request header value for the name of the shop.