### PR TITLE
Subscription and Polling endpoints

### DIFF
--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Constants.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Constants.cs
@@ -3,6 +3,8 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier
 {
     public class Constants
     {
+        public const string ZapierWorkflowTypeId = "d05b95e5-86f8-4c31-99b8-4ec7fc62a787";
+
         public const string UmbracoFormsIntegrationsAutomationZapierUserGroup = "Umbraco.Forms.Integrations.Automation.Zapier.UserGroup";
 
         public static class ZapierAppConfiguration

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Constants.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Constants.cs
@@ -5,6 +5,13 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier
     {
         public const string UmbracoFormsIntegrationsAutomationZapierUserGroup = "Umbraco.Forms.Integrations.Automation.Zapier.UserGroup";
 
+        public static class ZapierAppConfiguration
+        {
+            public const string UsernameHeaderKey = "X-USERNAME";
+
+            public const string PasswordHeaderKey = "X-PASSWORD";
+        }
+
         public static class Configuration
         {
             public const string Settings = "Umbraco:Forms:Integrations:Automation:Zapier:Settings";

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Controllers/PollingController.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Controllers/PollingController.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+
+using System.Linq;
+using Umbraco.Forms.Core.Data.Storage;
+using Umbraco.Forms.Core.Providers.Models;
+using Umbraco.Forms.Core.Services;
+using Umbraco.Forms.Integrations.Automation.Zapier.Configuration;
+using Umbraco.Forms.Integrations.Automation.Zapier.Services;
+
+#if NETCOREAPP
+using Microsoft.Extensions.Options;
+
+using Umbraco.Cms.Web.Common.Controllers;
+using Umbraco.Cms.Core.Services;
+#else
+using System.Configuration;
+
+using Umbraco.Web.WebApi;
+using Umbraco.Core.Services;
+#endif
+
+namespace Umbraco.Forms.Integrations.Automation.Zapier.Controllers
+{
+    public class PollingController : UmbracoApiController
+    {
+        private readonly ZapierSettings Options;
+
+        private readonly IFormService _formService;
+
+        private readonly IWorkflowService _workflowService;
+
+        private readonly IRecordReaderService _recordReaderService;
+
+        private readonly IUserValidationService _userValidationService;
+
+#if NETCOREAPP
+        public PollingController(IOptions<ZapierSettings> options, IFormService formService, IWorkflowService workflowService,
+            IRecordReaderService recordReaderService, IUserValidationService userValidationService)
+#else
+        public PollingController(IFormService formService, IWorkflowService workflowService, 
+            IRecordReaderService recordReaderService, IUserValidationService userValidationService)
+#endif
+        {
+#if NETCOREAPP
+            Options = options.Value;
+#else
+            Options = new ZapierSettings(ConfigurationManager.AppSettings);
+#endif
+
+            _formService = formService;
+
+            _workflowService = workflowService;
+
+            _recordReaderService = recordReaderService;
+
+            _userValidationService = userValidationService;
+        }
+
+        public List<Dictionary<string, string>> GetFormsData()
+        {
+            var formsData = new List<Dictionary<string, string>>();
+
+            string username = string.Empty;
+            string password = string.Empty;
+
+#if NETCOREAPP
+            if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.UsernameHeaderKey,
+                    out var usernameValues))
+                username = usernameValues.First();
+            if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.PasswordHeaderKey,
+                    out var passwordValues))
+                password = passwordValues.First();
+#else
+                        if (Request.Headers.TryGetValues(Constants.ZapierAppConfiguration.UsernameHeaderKey,
+                                out var usernameValues))
+                            username = usernameValues.First();
+                        if (Request.Headers.TryGetValues(Constants.ZapierAppConfiguration.PasswordHeaderKey,
+                                out var passwordValues))
+                            password = passwordValues.First();
+#endif
+
+            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password)) return null;
+
+            var isAuthorized = _userValidationService.Validate(username, password, Options.UserGroup).GetAwaiter().GetResult();
+            if (!isAuthorized) return null;
+
+            var zapierWorkflowId = new Guid("d05b95e5-86f8-4c31-99b8-4ec7fc62a787");
+
+            // 1. get forms
+            var forms = _formService.Get();
+            foreach (var form in forms)
+            {
+#if NETCOREAPP
+                var hasZapierWorkflow = _workflowService.Get(form).Any(p => p.WorkflowTypeId == zapierWorkflowId);
+#else
+                var hasZapierWorkflow = form.WorkflowIds.Contains(zapierWorkflowId);
+#endif
+
+                if (hasZapierWorkflow)
+                    formsData.Add(new Dictionary<string, string>
+                    {
+                        { Enum.GetName(typeof(StandardField), StandardField.FormId), form.Id.ToString() },
+                        { Enum.GetName(typeof(StandardField), StandardField.FormName), form.Name },
+                        { Enum.GetName(typeof(StandardField), StandardField.PageUrl), "/" },
+                        { Enum.GetName(typeof(StandardField), StandardField.SubmissionDate), DateTime.Now.ToString() }
+                    });
+            }
+
+            return formsData;
+        }
+
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Controllers/SubscriptionController.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Controllers/SubscriptionController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Net;
 using Umbraco.Forms.Core.Services;
 using Umbraco.Forms.Integrations.Automation.Zapier.Configuration;
 using Umbraco.Forms.Integrations.Automation.Zapier.Models.Dtos;
@@ -45,16 +44,14 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier.Controllers
             Options = options.Value;
 
             _logger = logger;
-#else
-            Options = new ZapierSettings(ConfigurationManager.AppSettings);
-#endif
-            _formService = formService;
 
-#if NETCOREAPP
             _workflowService = workflowService;
 #else
+            Options = new ZapierSettings(ConfigurationManager.AppSettings);
+
             _workflowServices = workflowServices;
 #endif
+            _formService = formService;
 
             _userValidationService = userValidationService;
         }
@@ -66,12 +63,12 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier.Controllers
             string password = string.Empty;
 
 #if NETCOREAPP
-                        if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.UsernameHeaderKey, 
-                                out var usernameValues))
-                            username = usernameValues.First();
-                        if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.PasswordHeaderKey, 
-                                out var passwordValues))
-                            password = passwordValues.First();
+            if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.UsernameHeaderKey,
+                    out var usernameValues))
+                username = usernameValues.First();
+            if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.PasswordHeaderKey,
+                    out var passwordValues))
+                password = passwordValues.First();
 #else
             if (Request.Headers.TryGetValues(Constants.ZapierAppConfiguration.UsernameHeaderKey,
                     out var usernameValues))
@@ -88,8 +85,6 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier.Controllers
 
             if (dto == null) return false;
 
-            var zapierWorkflowTypeId = new Guid("d05b95e5-86f8-4c31-99b8-4ec7fc62a787");
-
             try
             {
                 // 1. get forms
@@ -98,10 +93,11 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier.Controllers
                 {
                     // 2. check if 'Trigger Zapier' workflow exists on the form
 #if NETCOREAPP
-                    var zapierWorkflows = _workflowService.Get(form).Where(p => p.WorkflowTypeId == zapierWorkflowTypeId).ToList();
+                    var zapierWorkflows = _workflowService.Get(form)
+                        .Where(p => p.WorkflowTypeId == new Guid(Constants.ZapierWorkflowTypeId)).ToList();
 #else
                     var zapierWorkflows = _workflowServices.Get(form)
-                        .Where(p => p.WorkflowTypeId == zapierWorkflowTypeId).ToList();
+                        .Where(p => p.WorkflowTypeId == new Guid(Constants.ZapierWorkflowTypeId)).ToList();
 #endif
                     if (zapierWorkflows.Any())
                     {

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Controllers/SubscriptionController.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Controllers/SubscriptionController.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using Umbraco.Forms.Core.Services;
+using Umbraco.Forms.Integrations.Automation.Zapier.Configuration;
+using Umbraco.Forms.Integrations.Automation.Zapier.Models.Dtos;
+using Umbraco.Forms.Integrations.Automation.Zapier.Services;
+
+#if NETCOREAPP
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Web.Common.Controllers;
+#else
+using System.Web.Http;
+using System.Configuration;
+using Umbraco.Web.WebApi;
+#endif
+
+namespace Umbraco.Forms.Integrations.Automation.Zapier.Controllers
+{
+    public class SubscriptionController : UmbracoApiController
+    {
+        private readonly ZapierSettings Options;
+
+#if NETCOREAPP
+        private readonly ILogger<SubscriptionController> _logger;
+
+        private readonly IWorkflowService _workflowService;
+#else
+        private readonly IWorkflowServices _workflowServices;
+#endif
+
+        private readonly IFormService _formService;
+
+        private readonly IUserValidationService _userValidationService;
+
+#if NETCOREAPP
+        public SubscriptionController(IOptions<ZapierSettings> options, ILogger<SubscriptionController> logger, IFormService formService, IWorkflowService workflowService, IUserValidationService userValidationService)
+#else
+        public SubscriptionController(IFormService formService, IWorkflowServices workflowServices, IUserValidationService userValidationService)
+#endif
+        {
+#if NETCOREAPP
+            Options = options.Value;
+
+            _logger = logger;
+#else
+            Options = new ZapierSettings(ConfigurationManager.AppSettings);
+#endif
+            _formService = formService;
+
+#if NETCOREAPP
+            _workflowService = workflowService;
+#else
+            _workflowServices = workflowServices;
+#endif
+
+            _userValidationService = userValidationService;
+        }
+
+        [HttpPost]
+        public bool UpdatePreferences([FromBody] SubscriptionDto dto)
+        {
+            string username = string.Empty;
+            string password = string.Empty;
+
+#if NETCOREAPP
+                        if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.UsernameHeaderKey, 
+                                out var usernameValues))
+                            username = usernameValues.First();
+                        if (Request.Headers.TryGetValue(Constants.ZapierAppConfiguration.PasswordHeaderKey, 
+                                out var passwordValues))
+                            password = passwordValues.First();
+#else
+            if (Request.Headers.TryGetValues(Constants.ZapierAppConfiguration.UsernameHeaderKey,
+                    out var usernameValues))
+                username = usernameValues.First();
+            if (Request.Headers.TryGetValues(Constants.ZapierAppConfiguration.PasswordHeaderKey,
+                    out var passwordValues))
+                password = passwordValues.First();
+#endif
+
+            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password)) return false;
+
+            var isAuthorized = _userValidationService.Validate(username, password, Options.UserGroup).GetAwaiter().GetResult();
+            if (!isAuthorized) return false;
+
+            if (dto == null) return false;
+
+            var zapierWorkflowTypeId = new Guid("d05b95e5-86f8-4c31-99b8-4ec7fc62a787");
+
+            try
+            {
+                // 1. get forms
+                var forms = _formService.Get();
+                foreach (var form in forms)
+                {
+                    // 2. check if 'Trigger Zapier' workflow exists on the form
+#if NETCOREAPP
+                    var zapierWorkflows = _workflowService.Get(form).Where(p => p.WorkflowTypeId == zapierWorkflowTypeId).ToList();
+#else
+                    var zapierWorkflows = _workflowServices.Get(form)
+                        .Where(p => p.WorkflowTypeId == zapierWorkflowTypeId).ToList();
+#endif
+                    if (zapierWorkflows.Any())
+                    {
+                        foreach (var zapierWorkflow in zapierWorkflows)
+                        {
+                            // 3. check if request hook URL matches with the WebHookUri property of the workflow. If match found, set Active property.
+                            if (zapierWorkflow.Settings[nameof(ZapierWorkflow.WebHookUri)] == dto.HookUrl)
+                            {
+                                zapierWorkflow.Active = dto.Enable;
+
+#if NETCOREAPP
+                                _workflowService.Update(zapierWorkflow);
+#else
+                                _workflowServices.Update(zapierWorkflow);
+#endif
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+#if NETCOREAPP
+                _logger.LogError(e.Message);
+#else
+                Logger.Error(typeof(SubscriptionController), e);
+#endif
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Models/Dtos/SubscriptionDto.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Models/Dtos/SubscriptionDto.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Umbraco.Forms.Integrations.Automation.Zapier.Models.Dtos
+{
+    public class SubscriptionDto
+    {
+        [JsonProperty("hookUrl")]
+        public string HookUrl { get; set; }
+
+        [JsonProperty("enable")]
+        public bool Enable { get; set; }
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Services/IUserValidationService.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Services/IUserValidationService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Umbraco.Forms.Integrations.Automation.Zapier.Services
+{
+    public interface IUserValidationService
+    {
+        Task<bool> Validate(string username, string password, string userGroup);
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Services/UserValidationService.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Services/UserValidationService.cs
@@ -1,0 +1,54 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+
+#if NETCOREAPP
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+#else
+using Umbraco.Core.Services;
+using Umbraco.Web;
+#endif
+
+namespace Umbraco.Forms.Integrations.Automation.Zapier.Services
+{
+    public class UserValidationService : IUserValidationService
+    {
+        private readonly IUserService _userService;
+
+
+#if NETCOREAPP
+        private readonly IBackOfficeUserManager _backOfficeUserManager;
+
+        public UserValidationService(IBackOfficeUserManager backOfficeUserManager, IUserService userService)
+        {
+            _backOfficeUserManager = backOfficeUserManager;
+        }
+#else
+        public UserValidationService(IUserService userService)
+        {
+            _userService = userService;
+        }
+#endif
+
+        public async Task<bool> Validate(string username, string password, string userGroup)
+        {
+#if NETCOREAPP
+            var isUserValid =
+                await _backOfficeUserManager.ValidateCredentialsAsync(username, password);
+#else
+            var isUserValid = Umbraco.Web.Composing.Current.UmbracoContext.Security.ValidateBackOfficeCredentials(username, password);
+#endif
+
+            if (!isUserValid) return false;
+
+            if (!string.IsNullOrEmpty(userGroup))
+            {
+                var user = _userService.GetByUsername(username);
+
+                return user != null && user.Groups.Any(p => p.Name == userGroup);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/ZapierComposer.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/ZapierComposer.cs
@@ -8,6 +8,8 @@ using Umbraco.Forms.Integrations.Automation.Zapier.Configuration;
 #else
 using Umbraco.Core.Composing;
 #endif
+using Umbraco.Core;
+using Umbraco.Forms.Integrations.Automation.Zapier.Services;
 
 namespace Umbraco.Forms.Integrations.Automation.Zapier
 {
@@ -21,11 +23,13 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier
                 .Bind(builder.Config.GetSection(Constants.Configuration.Settings));
 
             builder.WithCollectionBuilder<WorkflowCollectionBuilder>().Add<ZapierWorkflow>();
+
+            builder.Services.AddScoped<IUserValidationService, UserValidationService>();
         }
 #else
         public void Compose(Composition composition)
         {
-            
+            composition.Register<IUserValidationService, UserValidationService>(Lifetime.Scope);
         }
 #endif
     }

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/ZapierWorkflow.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/ZapierWorkflow.cs
@@ -9,6 +9,7 @@ using Umbraco.Forms.Integrations.Automation.Zapier.Services;
 using Umbraco.Forms.Integrations.Automation.Zapier.Validators;
 
 #if NETCOREAPP
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Web;
@@ -77,8 +78,6 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier
 
         // Access to the client within the class is via ClientFactory(), allowing us to mock the responses in tests.
         public static Func<HttpClient> ClientFactory = () => s_client;
-
-
 
 #if NETCOREAPP
         public override WorkflowExecutionStatus Execute(WorkflowExecutionContext context)

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/ZapierWorkflow.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/ZapierWorkflow.cs
@@ -9,12 +9,9 @@ using Umbraco.Forms.Integrations.Automation.Zapier.Services;
 using Umbraco.Forms.Integrations.Automation.Zapier.Validators;
 
 #if NETCOREAPP
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Routing;
-using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common;
-
 #else
 using Umbraco.Web;
 using Umbraco.Forms.Core.Persistence.Dtos;
@@ -40,7 +37,7 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier
             _logger = logger;
 
             Name = "Trigger Zap";
-            Id = new Guid("d05b95e5-86f8-4c31-99b8-4ec7fc62a787");
+            Id = new Guid(Constants.ZapierWorkflowTypeId);
             Description = "Automation workflow for triggering Zaps in Zapier.";
             Icon = "icon-tools";
         }
@@ -52,7 +49,7 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier
             _umbracoContextAccessor = umbracoContextAccessor;
 
             Name = "Trigger Zap";
-            Id = new Guid("d05b95e5-86f8-4c31-99b8-4ec7fc62a787");
+            Id = new Guid(Constants.ZapierWorkflowTypeId);
             Description = "Automation workflow for triggering Zaps in Zapier.";
             Icon = "icon-tools";
         }


### PR DESCRIPTION
Current updates are required features in the Zapier app validation process and cover the following:

- _Subscribe/Unsubscribe_ - endpoint that will facilitate enabling or disabling the Zapier workflow attached to forms based on the hook URL that is sent in the body of the Zapier request, alongside a Boolean flag toggling the status.
- _Polling_ - endpoint used by Zapier when Zap triggers are designed and provide sample requests to the user in the _Test Trigger_ section of the Zap.

The two endpoints use the header keys _X-USERNAME_ and _X-PASSWORD_ to validate the Zapier request. 