### PR TITLE
Allow for additional fields to be passed from a custom workflow

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspot-field-mapper-template.html
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspot-field-mapper-template.html
@@ -8,7 +8,7 @@
         <p>Umbraco Forms is not configured with a HubSpot CRM account.</p>
         <p>To do this you can either create and save an API key into the <i>UmbracoForms.config</i> file.</p>
         <p>Or you can click <a ng-click="vm.openAuth()" style="text-decoration: underline">here</a> to complete an OAuth connection.</p>
-        <p><em>If your browser is unable to process the automated connection, paste the provided authorization code below and click to complete the authentication.</em></dd>
+        <p><em>If your browser is unable to process the automated connection, paste the provided authorization code below and click to complete the authentication.</em>
         <input type="text" placeholder="Enter authorization code" ng-model="vm.authorizationCode" />
         <umb-button type="button" disabled="vm.authorizationCode === ''" action="vm.authorize()" label="Authorize"></umb-button>
     </div>

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/HubspotWorkflow.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/HubspotWorkflow.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot
                 return WorkflowExecutionStatus.NotConfigured;
             }
 
-            var commandResult = _contactService.PostContactAsync(record, fieldMappings).GetAwaiter().GetResult();
+            var commandResult = _contactService.PostContactAsync(record, fieldMappings, null).GetAwaiter().GetResult();
             switch (commandResult)
             {
                 case CommandResult.NotConfigured:

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/IContactService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/IContactService.cs
@@ -26,6 +26,6 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
 
         Task<IEnumerable<Property>> GetContactPropertiesAsync();
 
-        Task<CommandResult> PostContactAsync(Record record, List<MappedProperty> fieldMappings);
+        Task<CommandResult> PostContactAsync(Record record, List<MappedProperty> fieldMappings, Dictionary<string, string> additionalFields);
     }
 }


### PR DESCRIPTION
Adds the ability to pass a set of custom fields/values (not from the form you're working on, i.e. values such as lead source) if you create a custom workflow.
Also a couple of typo corrections that I noticed.