### PR TITLE
Updates HubSpot contact properties if record already exists based on email address.

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/Requests/PropertiesRequestV1.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/Requests/PropertiesRequestV1.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Umbraco.Forms.Integrations.Crm.Hubspot
+{
+    internal class PropertiesRequestV1
+    {
+        [JsonProperty(PropertyName = "properties")]
+        public IList<PropertyValue> Properties { get; set; } = new List<PropertyValue>();
+
+        internal class PropertyValue
+        {
+            public PropertyValue(string property, string value)
+            {
+                Property = property;
+                Value = value;
+            }
+
+            [JsonProperty(PropertyName = "property")]
+            public string Property { get; }
+
+            [JsonProperty(PropertyName = "value")]
+            public string Value { get; }
+        }
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/Requests/PropertiesRequestV3.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/Requests/PropertiesRequestV3.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Umbraco.Forms.Integrations.Crm.Hubspot
 {
-    internal class PropertiesRequest
+    internal class PropertiesRequestV3
     {
         [JsonProperty(PropertyName = "properties")]
         public JObject Properties { get; set; } = new JObject();

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/IContactService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/IContactService.cs
@@ -26,6 +26,8 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
 
         Task<IEnumerable<Property>> GetContactPropertiesAsync();
 
+        Task<CommandResult> PostContactAsync(Record record, List<MappedProperty> fieldMappings);
+
         Task<CommandResult> PostContactAsync(Record record, List<MappedProperty> fieldMappings, Dictionary<string, string> additionalFields);
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Umbraco.Forms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Umbraco.Forms.Integrations.Crm.Hubspot.csproj
@@ -11,7 +11,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Forms.Integrations</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Forms.Integrations</RepositoryUrl>
-		<Version>1.1.2</Version>
+		<Version>2.0.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 	</PropertyGroup>


### PR DESCRIPTION
Resolves issue #17, by submitting an update to a contact based on their email address if the first attempt to save a new contact fails due to a record already existing.

Have bumped to version 2 as there's a breaking change come in from a PR and also as this is a change to behaviour (it might be some people wouldn't want to do an update, so they should opt into it by upgrading).