### PR TITLE
Form polling update

### DIFF
--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Controllers/FormPollingController.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Controllers/FormPollingController.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Forms.Core.Data.Storage;
+using Umbraco.Forms.Core.Services;
 using Umbraco.Forms.Integrations.Automation.Zapier.Extensions;
 using Umbraco.Forms.Integrations.Automation.Zapier.Helpers;
 using Umbraco.Forms.Integrations.Automation.Zapier.Services;
@@ -50,14 +52,9 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier.Controllers
 
             var form = _zapierFormService.GetById(id);
 
-            var latestFormRecord = _recordStorage.GetAllRecords(form)
-                .OrderByDescending(p => p.Created)
-                .FirstOrDefault();
+            if(form == null) return new List<Dictionary<string, string>>();
 
-            return form != null && latestFormRecord != null
-                ? new List<Dictionary<string, string>>
-                    {form.ToFormDictionary(latestFormRecord, _umbUrlHelper.GetPageUrl(latestFormRecord.UmbracoPageId))}
-                : new List<Dictionary<string, string>>();
+            return new List<Dictionary<string, string>> { form.ToEmptyFormDictionary() };
         }
     }
 }

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Extensions/FormExtensions.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Extensions/FormExtensions.cs
@@ -26,6 +26,24 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier.Extensions
             return contentDict;
         }
 
+        public static Dictionary<string, string> ToEmptyFormDictionary(this Form form)
+        {
+            var contentDict = new Dictionary<string, string>
+            {
+                { Constants.FormProperties.Id, form.Id.ToString() },
+                { Constants.FormProperties.Name, form.Name },
+                { Constants.FormProperties.SubmissionDate, DateTime.UtcNow.ToString("s") },
+                { Constants.FormProperties.PageUrl, string.Empty }
+            };
+
+            foreach (var field in form.AllFields)
+            {
+                contentDict.Add(field.Alias, string.Empty);
+            }
+
+            return contentDict;
+        }
+
         public static Dictionary<string, string> ToFormDictionary(this Form form)
         {
             var contentDict = new Dictionary<string, string>


### PR DESCRIPTION
Current PR fixes a performance issue when retrieving the entire list of records for a form.

When setting up a Zap for _New Form Submitted_ trigger, after the user is authenticated and he picks up a form, the next step in the trigger setup is to prompt the fields of the latest record,  fields that are going to be used in setting up the Zap action.
Initially this was achieved by pulling the entire records list for a form, resulting in a delay or a timeout.

This fix will no longer work with the form records, but will return a dictionary with fields aliases, but no value.