### PR TITLE
Allow contact update flag for CRM integrations: ActiveCampaign & HubSpot

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/ActiveCampaignContactsWorkflow.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/ActiveCampaignContactsWorkflow.cs
@@ -67,6 +67,13 @@ namespace Umbraco.Forms.Integrations.Crm.ActiveCampaign
                 // Check if contact exists.
                 var contacts = _contactService.Get(email).ConfigureAwait(false).GetAwaiter().GetResult();
 
+                if(contacts.Contacts.Count > 0 && !_settings.AllowContactUpdate)
+                {
+                    _logger.LogError("ActiveCampaign contact update is not allowed.");
+
+                    return WorkflowExecutionStatus.Cancelled;
+                }
+
                 var requestDto = new ContactDetailDto { Contact = Build(context.Record) };
 
                 if (contacts.Contacts.Count > 0) requestDto.Contact.Id = contacts.Contacts.First().Id;

--- a/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/ActiveCampaignContactsWorkflow.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/ActiveCampaignContactsWorkflow.cs
@@ -69,9 +69,9 @@ namespace Umbraco.Forms.Integrations.Crm.ActiveCampaign
 
                 if(contacts.Contacts.Count > 0 && !_settings.AllowContactUpdate)
                 {
-                    _logger.LogError("ActiveCampaign contact update is not allowed.");
+                    _logger.LogInformation("Contact already exists in ActiveCampaign and workflow is configured to not apply updates, so update of information was skipped.");
 
-                    return WorkflowExecutionStatus.Cancelled;
+                    return WorkflowExecutionStatus.Completed;
                 }
 
                 var requestDto = new ContactDetailDto { Contact = Build(context.Record) };

--- a/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/Configuration/ActiveCampaignSettings.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/Configuration/ActiveCampaignSettings.cs
@@ -8,11 +8,11 @@ namespace Umbraco.Forms.Integrations.Crm.ActiveCampaign.Configuration
             ContactFields = new List<ContactFieldSettings>();
         }
 
-        public string BaseUrl { get; set; }
+        public string BaseUrl { get; }
 
-        public string ApiKey { get; set; }
+        public string ApiKey { get; }
 
-        public bool AllowContactUpdate { get; set; }
+        public bool AllowContactUpdate { get; }
 
         public List<ContactFieldSettings> ContactFields { get; set; }
     }

--- a/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/Configuration/ActiveCampaignSettings.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/Configuration/ActiveCampaignSettings.cs
@@ -12,6 +12,8 @@ namespace Umbraco.Forms.Integrations.Crm.ActiveCampaign.Configuration
 
         public string ApiKey { get; set; }
 
+        public bool AllowContactUpdate { get; set; }
+
         public List<ContactFieldSettings> ContactFields { get; set; }
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Configuration/HubspotSettings.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Configuration/HubspotSettings.cs
@@ -3,7 +3,7 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Configuration
 {
     public class HubspotSettings
     {
-        public string ApiKey { get; }
+        public string ApiKey { get; set; }
 
         public bool AllowContactUpdate { get; }
     }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Configuration/HubspotSettings.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Configuration/HubspotSettings.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace Umbraco.Forms.Integrations.Crm.Hubspot.Configuration
 {
     public class HubspotSettings
     {
         public string ApiKey { get; set; }
+
+        public bool AllowContactUpdate { get; set; }
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Configuration/HubspotSettings.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Configuration/HubspotSettings.cs
@@ -3,8 +3,8 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Configuration
 {
     public class HubspotSettings
     {
-        public string ApiKey { get; set; }
+        public string ApiKey { get; }
 
-        public bool AllowContactUpdate { get; set; }
+        public bool AllowContactUpdate { get; }
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
@@ -203,10 +203,10 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                 if (response.StatusCode == HttpStatusCode.Conflict)
                 {
                     if (!_settings.AllowContactUpdate)
-                        _logger.LogError("Hubspot contact update is not allowed.");
+                        _logger.LogInformation("Contact already exists in HubSpot CRM and workflow is configured to not apply updates, so update of information was skipped.");
                     return _settings.AllowContactUpdate
                         ? await UpdateContactAsync(record, authenticationDetails, propertiesRequestV1, emailValue)
-                        : CommandResult.Failed;
+                        : CommandResult.Success;
                 }
                 else
                 {

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
@@ -202,7 +202,11 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                 // A 409 - Conflict response indicates that the contact (by email address) already exists.
                 if (response.StatusCode == HttpStatusCode.Conflict)
                 {
-                    return await UpdateContactAsync(record, authenticationDetails, propertiesRequestV1, emailValue);
+                    if (!_settings.AllowContactUpdate)
+                        _logger.LogError("Hubspot contact update is not allowed.");
+                    return _settings.AllowContactUpdate
+                        ? await UpdateContactAsync(record, authenticationDetails, propertiesRequestV1, emailValue)
+                        : CommandResult.Failed;
                 }
                 else
                 {


### PR DESCRIPTION
This PR handles the use case when a CRM contact can be updated just by knowing his email address.
As a consequence, the update operation can be disabled using the _AllowContactUpdate_ flag.