### PR TITLE
HubSpot support for Private Access Tokens.

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspot-field-mapper-template.html
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspot-field-mapper-template.html
@@ -6,7 +6,7 @@
 
     <div ng-show="!vm.loading && vm.authorizationStatus === 'Unauthenticated'">
         <p>Umbraco Forms is not configured with a HubSpot CRM account.</p>
-        <p>To do this you can either create and save an API key into the <i>UmbracoForms.config</i> file.</p>
+        <p>To do this you can either create and save an API key or a Private Access Token into the <i>appsettings.json</i> file.</p>
         <p>Or you can click <a ng-click="vm.openAuth()" style="text-decoration: underline">here</a> to complete an OAuth connection.</p>
         <p><em>If your browser is unable to process the automated connection, paste the provided authorization code below and click to complete the authentication.</em>
         <input type="text" placeholder="Enter authorization code" ng-model="vm.authorizationCode" />
@@ -15,7 +15,11 @@
 
     <div ng-show="!vm.loading && vm.authorizationStatus !== 'Unauthenticated'">
 
-        <div class="umb-forms-mappings" ng-show="vm.mappings.length > 0 && vm.hubspotFields.length > 0">
+        <div class="umb-forms-settings-note ng-scope">
+            Umbraco Forms is configured with a HubSpot CRM account using: <b>{{ vm.authorizationStatus }}</b></p>
+        </div>
+
+        <div class="umb-forms-mappings mt2" ng-show="vm.mappings.length > 0 && vm.hubspotFields.length > 0">
 
             <div class="umb-forms-mapping-header">
                 <div class="umb-forms-mapping-field -no-margin-left">Form Field</div>
@@ -54,10 +58,12 @@
             </div>
         </div>
 
-        <umb-button type="button" action="vm.addMapping()" label="Add mapping"></umb-button>
+        <div class="mt2">
+            <umb-button type="button" action="vm.addMapping()" label="Add mapping"></umb-button>
 
-        <div ng-show="vm.authorizationStatus === 'OAuth'" style="margin-top: 20px">
-            <umb-button type="button" action="vm.deauthorize()" label="De-authorize from Hubspot"></umb-button>
+            <div ng-show="vm.authorizationStatus === 'OAuth'" style="margin-top: 20px">
+                <umb-button type="button" action="vm.deauthorize()" label="De-authorize from Hubspot"></umb-button>
+            </div>
         </div>
 
     </div>

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Configuration/HubspotSettings.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Configuration/HubspotSettings.cs
@@ -5,6 +5,8 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Configuration
     {
         public string ApiKey { get; set; }
 
+        public string PrivateAccessToken { get; set; }
+
         public bool AllowContactUpdate { get; set; }
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/AuthenticationDetail.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/AuthenticationDetail.cs
@@ -4,6 +4,7 @@
     {
         Unauthenticated,
         ApiKey,
+        PrivateAccessToken,
         OAuth
     }
 
@@ -11,13 +12,29 @@
     {
         public string ApiKey { get; set; }
 
+        public string PrivateAccessToken { get; set; }
+
         public string RefreshToken { get; set; }
 
-        public AuthenticationMode Mode =>
-            !string.IsNullOrEmpty(ApiKey)
-                ? AuthenticationMode.ApiKey
-                : !string.IsNullOrEmpty(RefreshToken)
-                    ? AuthenticationMode.OAuth
-                    : AuthenticationMode.Unauthenticated;
+        public AuthenticationMode Mode
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(ApiKey)
+                    && string.IsNullOrEmpty(PrivateAccessToken)
+                    && string.IsNullOrEmpty(RefreshToken))
+                    return AuthenticationMode.Unauthenticated;
+
+                if(!string.IsNullOrEmpty(ApiKey))
+                {
+                    return AuthenticationMode.ApiKey;
+                } else if(!string.IsNullOrEmpty(PrivateAccessToken))
+                {
+                    return AuthenticationMode.PrivateAccessToken;
+                }
+
+                return AuthenticationMode.OAuth;
+            }
+        }
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
@@ -273,6 +273,10 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
             {
                 authentication.ApiKey = apiKey;
             }
+            else if (TryGetPrivateAccessToken(out string privateAccessToken))
+            {
+                authentication.PrivateAccessToken = privateAccessToken;
+            }
             else if (TryGetSavedRefreshToken(out string refreshToken))
             {
                 authentication.RefreshToken = refreshToken;
@@ -286,6 +290,13 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
             apiKey = _settings.ApiKey;
 
             return !string.IsNullOrEmpty(apiKey);
+        }
+
+        private bool TryGetPrivateAccessToken(out string accessToken)
+        {
+            accessToken = _settings.PrivateAccessToken;
+
+            return !string.IsNullOrEmpty(accessToken);
         }
 
         private bool TryGetSavedRefreshToken(out string refreshToken)
@@ -366,6 +377,10 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                 {
                     case AuthenticationMode.ApiKey:
                         requestMessage.RequestUri = new Uri($"{url}?hapikey={authenticationDetails.ApiKey}");
+                        break;
+                    case AuthenticationMode.PrivateAccessToken:
+                        requestMessage.Headers.Authorization =
+                           new AuthenticationHeaderValue("Bearer", authenticationDetails.PrivateAccessToken);
                         break;
                     case AuthenticationMode.OAuth:
                         requestMessage.Headers.Authorization =


### PR DESCRIPTION
This PR contains updates to the Umbraco Forms integration with HubSpot to include support for Private Access Tokens.

As HubSpot has removed support for API keys, the current authentication modes include Private Access Tokens generated through a Private App, and OAuth - using the Umbraco app. Also, as the CMS integration with HubSpot is aligned with the use of Private Access Tokens, I considered this a good chance to address the integration with Forms as well.

With this update I have also included some small UI changes to present the editor with details on the authentication mode:
![image](https://user-images.githubusercontent.com/95346674/234641082-d9ceb013-c98b-49e7-84db-671fd977bc71.png)
![image](https://user-images.githubusercontent.com/95346674/234641371-2ffeacef-1655-4c6e-80c3-dcdfe717dd7c.png)

The updates target Umbraco 10+, once the updates are approved I will adapt the changes for Umbraco 8.

