### PR TITLE
HubSpot private access tokens support and version update.

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspot-field-mapper-template.html
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspot-field-mapper-template.html
@@ -1,3 +1,16 @@
+<style>
+    .umb-forms-settings-note {
+        font-size: 14px;
+        margin-top: 10px;
+        padding: 8px;
+        background-color: #1b264f;
+        border: 1px solid #1d1d1d;
+        color: #fff;
+        border-radius: 5px;
+        display: inline-block;
+    }
+</style>
+
 <div>
     <!--
     <pre>{{ vm.setting | json }}</pre>
@@ -6,7 +19,7 @@
 
     <div ng-show="!vm.loading && vm.authorizationStatus === 'Unauthenticated'">
         <p>Umbraco Forms is not configured with a HubSpot CRM account.</p>
-        <p>To do this you can either create and save an API key into the <i>UmbracoForms.config</i> file.</p>
+        <p>To do this you can either create and save an API key or a Private Access Token into the <i>UmbracoForms.config</i> file.</p>
         <p>Or you can click <a ng-click="vm.openAuth()" style="text-decoration: underline">here</a> to complete an OAuth connection.</p>
         <p><em>If your browser is unable to process the automated connection, paste the provided authorization code below and click to complete the authentication.</em>
         <input type="text" placeholder="Enter authorization code" ng-model="vm.authorizationCode" />
@@ -15,7 +28,11 @@
 
     <div ng-show="!vm.loading && vm.authorizationStatus !== 'Unauthenticated'">
 
-        <div class="umb-forms-mappings" ng-show="vm.mappings.length > 0 && vm.hubspotFields.length > 0">
+        <div class="umb-forms-settings-note">
+            Umbraco Forms is configured with a HubSpot CRM account using: <b>{{ vm.authorizationStatus }}</b></p>
+        </div>
+
+        <div class="umb-forms-mappings mt2" ng-show="vm.mappings.length > 0 && vm.hubspotFields.length > 0">
 
             <div class="umb-forms-mapping-header">
                 <div class="umb-forms-mapping-field -no-margin-left">Form Field</div>
@@ -54,10 +71,12 @@
             </div>
         </div>
 
-        <umb-button type="button" action="vm.addMapping()" label="Add mapping"></umb-button>
+        <div class="mt2">
+            <umb-button type="button" action="vm.addMapping()" label="Add mapping"></umb-button>
 
-        <div ng-show="vm.authorizationStatus === 'OAuth'" style="margin-top: 20px">
-            <umb-button type="button" action="vm.deauthorize()" label="De-authorize from Hubspot"></umb-button>
+            <div ng-show="vm.authorizationStatus === 'OAuth'" style="margin-top: 20px">
+                <umb-button type="button" action="vm.deauthorize()" label="De-authorize from Hubspot"></umb-button>
+            </div>
         </div>
 
     </div>

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/AuthenticationDetail.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/AuthenticationDetail.cs
@@ -4,6 +4,7 @@
     {
         Unauthenticated,
         ApiKey,
+        PrivateAccessToken,
         OAuth
     }
 
@@ -11,13 +12,30 @@
     {
         public string ApiKey { get; set; }
 
+        public string PrivateAccessToken { get; set; }
+
         public string RefreshToken { get; set; }
 
-        public AuthenticationMode Mode =>
-            !string.IsNullOrEmpty(ApiKey)
-                ? AuthenticationMode.ApiKey
-                : !string.IsNullOrEmpty(RefreshToken)
-                    ? AuthenticationMode.OAuth
-                    : AuthenticationMode.Unauthenticated;
+        public AuthenticationMode Mode
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(ApiKey)
+                   && string.IsNullOrEmpty(PrivateAccessToken)
+                   && string.IsNullOrEmpty(RefreshToken))
+                    return AuthenticationMode.Unauthenticated;
+
+                if (!string.IsNullOrEmpty(ApiKey))
+                {
+                    return AuthenticationMode.ApiKey;
+                }
+                else if (!string.IsNullOrEmpty(PrivateAccessToken))
+                {
+                    return AuthenticationMode.PrivateAccessToken;
+                }
+
+                return AuthenticationMode.OAuth;
+            }
+        }
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
@@ -271,6 +271,10 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
             {
                 authentication.ApiKey = apiKey;
             }
+            else if (TryGetPrivateAccessToken(out string privateAccessToken))
+            {
+                authentication.PrivateAccessToken = privateAccessToken;
+            }
             else if (TryGetSavedRefreshToken(out string refreshToken))
             {
                 authentication.RefreshToken = refreshToken;
@@ -283,6 +287,12 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
         {
             apiKey = _configuration.GetSetting("HubSpotApiKey");
             return !string.IsNullOrEmpty(apiKey);
+        }
+
+        private bool TryGetPrivateAccessToken(out string privateAccessToken)
+        {
+            privateAccessToken = _configuration.GetSetting("HubSpotPrivateAccessToken");
+            return !string.IsNullOrEmpty(privateAccessToken);
         }
 
         private bool TryGetSavedRefreshToken(out string refreshToken)
@@ -360,6 +370,10 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                 {
                     case AuthenticationMode.ApiKey:
                         requestMessage.RequestUri = new Uri($"{url}?hapikey={authenticationDetails.ApiKey}");
+                        break;
+                    case AuthenticationMode.PrivateAccessToken:
+                        requestMessage.Headers.Authorization =
+                            new AuthenticationHeaderValue("Bearer", authenticationDetails.PrivateAccessToken);
                         break;
                     case AuthenticationMode.OAuth:
                         requestMessage.Headers.Authorization =

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Umbraco.Forms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Umbraco.Forms.Integrations.Crm.Hubspot.csproj
@@ -11,7 +11,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Forms.Integrations/tree/main/src/Umbraco.Forms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Forms.Integrations</RepositoryUrl>
-		<Version>2.0.3</Version>
+		<Version>2.1.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR contains the updates for HubSpot with support for private access tokens for Umbraco 8, following the implementation for Umbraco 10+ from [this](https://github.com/umbraco/Umbraco.Forms.Integrations/pull/74) PR.