### PR TITLE
Feature/v10/hubspot crud

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Constants.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Constants.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Forms.Integrations.Crm.Hubspot;
+
+public class Constants
+{
+    public const string AccessTokenCacheKey = "HubSpotOAuthAccessToken";
+
+    public const string RefreshTokenDatabaseKey = "Umbraco.Forms.Integrations.Crm.Hubspot+RefreshToken";
+}

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Controllers/ContactsController.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Controllers/ContactsController.cs
@@ -1,0 +1,360 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Controllers;
+using Umbraco.Forms.Integrations.Crm.Hubspot.Configuration;
+using Umbraco.Forms.Integrations.Crm.Hubspot.Extensions;
+using Umbraco.Forms.Integrations.Crm.Hubspot.Filters;
+using Umbraco.Forms.Integrations.Crm.Hubspot.Models.Responses;
+using Umbraco.Forms.Integrations.Crm.Hubspot.Services;
+
+namespace Umbraco.Forms.Integrations.Crm.Hubspot.Controllers;
+
+[Route("umbraco/api/hubspot/v1/contacts")]
+public class ContactsController : UmbracoApiController
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    private readonly ILogger<ContactsController> _logger;
+    private readonly AppCaches _appCaches;
+    private readonly IKeyValueService _keyValueService;
+    private readonly IAuthenticationService _authenticationService;
+
+    private readonly HubspotSettings _settings;
+
+    private const string CrmApiHost = "https://api.hubapi.com";
+    private static readonly string CrmV3ApiBaseUrl = $"{CrmApiHost}/crm/v3/";
+    private const string InstallUrlFormat = "https://app-eu1.hubspot.com/oauth/authorize?client_id={0}&redirect_uri={1}&scope={2}";
+    private const string OAuthScopes = "oauth%20forms%20crm.objects.contacts.read%20crm.objects.contacts.write";
+    private const string OAuthClientId = "1a04f5bf-e99e-48e1-9d62-6c25bf2bdefe";
+    private const string JsonContentType = "application/json";
+
+    private const string OAuthBaseUrl = "https://hubspot-forms-auth.umbraco.com/";  // For local testing: "https://localhost:44364/"
+    private static string OAuthRedirectUrl = OAuthBaseUrl;
+    private static string OAuthTokenProxyUrl = $"{OAuthBaseUrl}oauth/v1/token";
+
+    public ContactsController(
+        IOptions<HubspotSettings> options,
+        IHttpClientFactory httpClientFactory,
+        ILogger<ContactsController> logger,
+        AppCaches appCaches,
+        IKeyValueService keyValueService,
+        IAuthenticationService authenticationService)
+    {
+        _settings = options.Value;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _appCaches = appCaches;
+        _keyValueService = keyValueService;
+        _authenticationService = authenticationService;
+    }
+
+    [HttpGet]
+    [ServiceFilter(typeof(ConfiguredAuthenticationFilterAttribute))]
+    public async Task<IActionResult> Get()
+    {
+        var authenticationDetails = _authenticationService.GetDetails();
+        var requestUrl = $"{CrmV3ApiBaseUrl}objects/contacts";
+        var httpMethod = HttpMethod.Get;
+        var response = await GetResponse(requestUrl, httpMethod).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode == false)
+        {
+            var retryResult = await HandleFailedRequest(response.StatusCode, requestUrl, httpMethod, authenticationDetails);
+            if (retryResult.Success)
+            {
+                response = retryResult.RetriedResponse;
+            }
+            else
+            {
+                _logger.LogError("Failed to fetch contact properties from HubSpot API for mapping. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                return BadRequest(response.ReasonPhrase);
+            }
+        }
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return Ok(JsonSerializer.Deserialize<ContactResponse>(responseContent));
+    }
+
+    [HttpGet]
+    [ServiceFilter(typeof(ConfiguredAuthenticationFilterAttribute))]
+    [Route("{id}")]
+    public async Task<IActionResult> Get(string id)
+    {
+        var requestUrl = $"{CrmV3ApiBaseUrl}objects/contacts/{id}";
+        var httpMethod = HttpMethod.Get;
+        var response = await GetResponse(requestUrl, httpMethod).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode == false)
+        {
+            var retryResult = await HandleFailedRequest(response.StatusCode, requestUrl, httpMethod);
+            if (retryResult.Success)
+            {
+                response = retryResult.RetriedResponse;
+            }
+            else
+            {
+                _logger.LogError("Failed to fetch contact properties from HubSpot API for mapping. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                return BadRequest(response.ReasonPhrase);
+            }
+        }
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return Ok(JsonSerializer.Deserialize<ContactDetail>(responseContent));
+    }
+
+    [HttpPost]
+    [ServiceFilter(typeof(ConfiguredAuthenticationFilterAttribute))]
+    public async Task<IActionResult> Create([FromBody] ContactDetail contact)
+    {
+        var requestUrl = $"{CrmV3ApiBaseUrl}/objects/contacts";
+        var httpMethod = HttpMethod.Post;
+        var response = await GetResponse(requestUrl, httpMethod, contact, JsonContentType)
+            .ConfigureAwait(false);
+        if (response.IsSuccessStatusCode == false)
+        {
+            var retryResult = await HandleFailedRequest(response.StatusCode, requestUrl, httpMethod);
+            if (retryResult.Success)
+            {
+                response = retryResult.RetriedResponse;
+            }
+            else
+            {
+                _logger.LogError("Failed to fetch contact properties from HubSpot API for mapping. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                return BadRequest(response.ReasonPhrase);
+            }
+        }
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var contactDetail = JsonSerializer.Deserialize<ContactDetail>(responseContent);
+        contact.Id = contactDetail.Id;
+
+        return Created($"contacts/{contactDetail.Id}", contact);
+    }
+
+    [HttpPatch]
+    [ServiceFilter(typeof(ConfiguredAuthenticationFilterAttribute))]
+    [Route("{id}")]
+    public async Task<IActionResult> Update(string id, [FromBody] ContactDetail contact)
+    {
+        var requestUrl = $"{CrmV3ApiBaseUrl}/objects/contacts/{id}";
+        var httpMethod = HttpMethod.Patch;
+        var response = await GetResponse(requestUrl, httpMethod, contact, JsonContentType)
+            .ConfigureAwait(false);
+        if (response.IsSuccessStatusCode == false)
+        {
+            var retryResult = await HandleFailedRequest(response.StatusCode, requestUrl, httpMethod);
+            if (retryResult.Success)
+            {
+                response = retryResult.RetriedResponse;
+            }
+            else
+            {
+                _logger.LogError("Failed to fetch contact properties from HubSpot API for mapping. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                return BadRequest(response.ReasonPhrase);
+            }
+        }
+
+        return Ok();
+    }
+
+    [HttpDelete]
+    [ServiceFilter(typeof(ConfiguredAuthenticationFilterAttribute))]
+    [Route("{id}")]
+    public async Task<IActionResult> Delete(string id)
+    {
+        var requestUrl = $"{CrmV3ApiBaseUrl}/objects/contacts/{id}";
+        var httpMethod = HttpMethod.Delete;
+        var response = await GetResponse(requestUrl, httpMethod)
+            .ConfigureAwait(false);
+        if (response.IsSuccessStatusCode == false)
+        {
+            var retryResult = await HandleFailedRequest(response.StatusCode, requestUrl, httpMethod);
+            if (retryResult.Success)
+            {
+                response = retryResult.RetriedResponse;
+            }
+            else
+            {
+                _logger.LogError("Failed to fetch contact properties from HubSpot API for mapping. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                return BadRequest(response.ReasonPhrase);
+            }
+        }
+
+        return NoContent();
+    }
+
+    #region Private Methods
+
+    private async Task<HttpResponseMessage> GetResponse(
+            string url,
+            HttpMethod httpMethod,
+            object content = null,
+            string contentType = null)
+    {
+        var authenticationDetails = _authenticationService.GetDetails();
+
+        var httpClient = _httpClientFactory.CreateClient();
+
+        var requestMessage = new HttpRequestMessage
+        {
+            Method = httpMethod,
+            RequestUri = new Uri(url),
+            Content = CreateRequestContent(content, contentType),
+        };
+
+        if (authenticationDetails != null)
+        {
+            // Apply appropriate authentication details to the request.  Either the API key as a querystring or the access token as a header.
+            switch (authenticationDetails.Mode)
+            {
+                case AuthenticationMode.ApiKey:
+                    requestMessage.RequestUri = new Uri($"{url}?hapikey={authenticationDetails.ApiKey}");
+                    break;
+                case AuthenticationMode.PrivateAccessToken:
+                    requestMessage.Headers.Authorization =
+                       new AuthenticationHeaderValue("Bearer", authenticationDetails.PrivateAccessToken);
+                    break;
+                case AuthenticationMode.OAuth:
+                    requestMessage.Headers.Authorization =
+                        new AuthenticationHeaderValue("Bearer",
+                            await GetOAuthAccessTokenFromCacheOrRefreshToken(authenticationDetails.RefreshToken).ConfigureAwait(false));
+                    break;
+            }
+        }
+
+        return await httpClient.SendAsync(requestMessage).ConfigureAwait(false);
+    }
+
+    private async Task RefreshOAuthAccessToken(string refreshToken)
+    {
+        var tokenRequest = new RefreshTokenRequest
+        {
+            ClientId = OAuthClientId,
+            RedirectUrl = OAuthRedirectUrl,
+            RefreshToken = refreshToken,
+        };
+        var response = await GetResponse(OAuthTokenProxyUrl, HttpMethod.Post, content: tokenRequest, contentType: "application/x-www-form-urlencoded").ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+        {
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(responseContent);
+
+            // Update the token details in the cache.
+            _appCaches.RuntimeCache.Insert(Constants.AccessTokenCacheKey, () => tokenResponse.AccessToken);
+
+            // Update the saved refresh token if we've got a different one.
+            if (tokenResponse.RefreshToken != refreshToken)
+            {
+                _keyValueService.SetValue(Constants.RefreshTokenDatabaseKey, tokenResponse.RefreshToken);
+            }
+        }
+        else
+        {
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            // Failed to refresh an access token from a refresh token, so remove what we have stored.
+            // Re-authentication via the authorization code will be required.
+            _keyValueService.SetValue(Constants.RefreshTokenDatabaseKey, string.Empty);
+
+            throw new InvalidOperationException(
+                $"Could not refresh OAuth token from HubSpot API. Status code: {response.StatusCode}, reason: {response.ReasonPhrase}, content: {responseContent}");
+        }
+    }
+
+    private static HttpContent CreateRequestContent(object data, string contentType)
+    {
+        if (data == null)
+        {
+            return null;
+        }
+
+        switch (contentType)
+        {
+            case JsonContentType:
+                var serializedData = JsonSerializer.Serialize(data);
+                return new StringContent(serializedData, Encoding.UTF8, contentType);
+            case "application/x-www-form-urlencoded":
+                return new FormUrlEncodedContent(data.AsDictionary());
+            default:
+                throw new InvalidOperationException($"Unexpected content type: {contentType}");
+        }
+    }
+
+    private async Task<string> GetOAuthAccessTokenFromCacheOrRefreshToken(string refreshToken)
+    {
+        var accessToken = _appCaches.RuntimeCache.Get(Constants.AccessTokenCacheKey);
+        if (accessToken != null)
+        {
+            // No access token in the cache, so get a new one from the refresh token.
+            await RefreshOAuthAccessToken(refreshToken).ConfigureAwait(false);
+            accessToken = _appCaches.RuntimeCache.Get(Constants.AccessTokenCacheKey).ToString();
+        }
+
+        return accessToken != null ? accessToken.ToString() : string.Empty;
+    }
+
+    private async Task<HandleFailedRequestResult> HandleFailedRequest(
+            HttpStatusCode statusCode,
+            string requestUrl,
+            HttpMethod httpMethod,
+            object content = null,
+            string contentType = "")
+    {
+        var authenticationDetails = _authenticationService.GetDetails();
+
+        var result = new HandleFailedRequestResult();
+        if (authenticationDetails.Mode == AuthenticationMode.OAuth)
+        {
+            if (statusCode == HttpStatusCode.Unauthorized)
+            {
+                // If we've got a 401 response and are using OAuth, likely our access token has expired.
+                // First we should try to refresh it using the refresh token.  If successful this will save the new
+                // value into the cache.
+                await RefreshOAuthAccessToken(authenticationDetails.RefreshToken);
+
+                // Repeat the operation using the refreshed token.
+                var response = await GetResponse(requestUrl, httpMethod, content, contentType).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
+                {
+                    result.Success = true;
+                    result.RetriedResponse = response;
+                }
+            }
+            else if (statusCode == HttpStatusCode.Forbidden)
+            {
+                HandleForbiddenResponse();
+            }
+        }
+
+        return result;
+    }
+
+    private void HandleForbiddenResponse()
+    {
+        // Token is no longer valid (perhaps due to additional scopes requested).  Need to clear and re-authenticate.
+        _keyValueService.SetValue(Constants.RefreshTokenDatabaseKey, string.Empty);
+    }
+
+    private class HandleFailedRequestResult
+    {
+        public bool Success { get; set; }
+
+        public HttpResponseMessage RetriedResponse { get; set; }
+    }
+    #endregion
+}

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Controllers/ContactsController.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Controllers/ContactsController.cs
@@ -34,12 +34,8 @@ public class ContactsController : UmbracoApiController
     private readonly IKeyValueService _keyValueService;
     private readonly IAuthenticationService _authenticationService;
 
-    private readonly HubspotSettings _settings;
-
     private const string CrmApiHost = "https://api.hubapi.com";
     private static readonly string CrmV3ApiBaseUrl = $"{CrmApiHost}/crm/v3/";
-    private const string InstallUrlFormat = "https://app-eu1.hubspot.com/oauth/authorize?client_id={0}&redirect_uri={1}&scope={2}";
-    private const string OAuthScopes = "oauth%20forms%20crm.objects.contacts.read%20crm.objects.contacts.write";
     private const string OAuthClientId = "1a04f5bf-e99e-48e1-9d62-6c25bf2bdefe";
     private const string JsonContentType = "application/json";
 
@@ -48,14 +44,12 @@ public class ContactsController : UmbracoApiController
     private static string OAuthTokenProxyUrl = $"{OAuthBaseUrl}oauth/v1/token";
 
     public ContactsController(
-        IOptions<HubspotSettings> options,
         IHttpClientFactory httpClientFactory,
         ILogger<ContactsController> logger,
         AppCaches appCaches,
         IKeyValueService keyValueService,
         IAuthenticationService authenticationService)
     {
-        _settings = options.Value;
         _httpClientFactory = httpClientFactory;
         _logger = logger;
         _appCaches = appCaches;
@@ -80,7 +74,7 @@ public class ContactsController : UmbracoApiController
             }
             else
             {
-                _logger.LogError("Failed to fetch contact properties from HubSpot API for mapping. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                _logger.LogError("Failed to fetch contacts from HubSpot API. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
                 return BadRequest(response.ReasonPhrase);
             }
         }
@@ -107,7 +101,7 @@ public class ContactsController : UmbracoApiController
             }
             else
             {
-                _logger.LogError("Failed to fetch contact properties from HubSpot API for mapping. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                _logger.LogError("Failed to fetch contact with id: {id} from HubSpot API. {StatusCode} {ReasonPhrase}", id, response.StatusCode, response.ReasonPhrase);
                 return BadRequest(response.ReasonPhrase);
             }
         }
@@ -134,7 +128,7 @@ public class ContactsController : UmbracoApiController
             }
             else
             {
-                _logger.LogError("Failed to fetch contact properties from HubSpot API for mapping. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                _logger.LogError("Failed to create contact. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
                 return BadRequest(response.ReasonPhrase);
             }
         }
@@ -164,7 +158,7 @@ public class ContactsController : UmbracoApiController
             }
             else
             {
-                _logger.LogError("Failed to fetch contact properties from HubSpot API for mapping. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                _logger.LogError("Failed to update contact with id: {id} from HubSpot API. {StatusCode} {ReasonPhrase}", id, response.StatusCode, response.ReasonPhrase);
                 return BadRequest(response.ReasonPhrase);
             }
         }
@@ -190,7 +184,7 @@ public class ContactsController : UmbracoApiController
             }
             else
             {
-                _logger.LogError("Failed to fetch contact properties from HubSpot API for mapping. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+                _logger.LogError("Failed to delete contact with id: {id} from HubSpot API. {StatusCode} {ReasonPhrase}", id, response.StatusCode, response.ReasonPhrase);
                 return BadRequest(response.ReasonPhrase);
             }
         }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Filters/ConfiguredAuthenticationFilterAttribute.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Filters/ConfiguredAuthenticationFilterAttribute.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Forms.Integrations.Crm.Hubspot.Services;
+
+namespace Umbraco.Forms.Integrations.Crm.Hubspot.Filters;
+
+public class ConfiguredAuthenticationFilterAttribute : IActionFilter
+{
+    private readonly ILogger<ConfiguredAuthenticationFilterAttribute> _logger;
+    private readonly IAuthenticationService _authenticationService;
+
+    public ConfiguredAuthenticationFilterAttribute(
+        ILogger<ConfiguredAuthenticationFilterAttribute> logger, 
+        IAuthenticationService authenticationService)
+    {
+        _logger = logger;
+        _authenticationService = authenticationService;
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+    }
+
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+        var authenticationDetails = _authenticationService.GetDetails();
+        if (authenticationDetails.Mode == AuthenticationMode.Unauthenticated)
+        {
+            const string message = "Cannot access HubSpot API via API key or OAuth, as neither a key has been configured nor a refresh token stored.";
+            _logger.LogInformation(message);
+            context.Result = new UnauthorizedObjectResult(message);
+        }
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/HubspotComposer.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/HubspotComposer.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Forms.Core.Providers;
 using Umbraco.Forms.Integrations.Crm.Hubspot.Configuration;
+using Umbraco.Forms.Integrations.Crm.Hubspot.Filters;
 using Umbraco.Forms.Integrations.Crm.Hubspot.Services;
 
 namespace Umbraco.Forms.Integrations.Crm.Hubspot
@@ -16,12 +17,17 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot
             builder.Services.AddOptions<HubspotSettings>()
                 .Bind(builder.Config.GetSection(HubspotWorkflow.HubspotSettings));
 
+            builder.Services.AddSingleton<IAuthenticationService, AuthenticationService>();
             builder.Services.AddSingleton<IContactService, HubspotContactService>();
 
             builder.AddNotificationHandler<ServerVariablesParsingNotification, HubspotServerVariablesParsingHandler>();
 
             builder.WithCollectionBuilder<WorkflowCollectionBuilder>()
                 .Add<HubspotWorkflow>();
+            
+            builder.Services.AddScoped<ConfiguredAuthenticationFilterAttribute>();
+
+
         }
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/Responses/Contact.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/Responses/Contact.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Umbraco.Forms.Integrations.Crm.Hubspot.Models.Responses;
+
+public class Contact
+{
+    [JsonPropertyName("firstname")]
+    public string FirstName { get; set; }
+
+    [JsonPropertyName("lastname")]
+    public string LastName { get; set; }
+
+    [JsonPropertyName("email")]
+    public string Email { get; set; }
+
+    [JsonPropertyName("company")]
+    public string Company { get; set; }
+}

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/Responses/ContactDetail.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/Responses/ContactDetail.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Umbraco.Forms.Integrations.Crm.Hubspot.Models.Responses;
+
+public class ContactDetail
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("properties")]
+    public Contact Properties { get; set; }
+}

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/Responses/ContactResponse.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/Responses/ContactResponse.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Umbraco.Forms.Integrations.Crm.Hubspot.Models.Responses;
+
+public class ContactResponse
+{
+    [JsonPropertyName("results")]
+    public List<ContactDetail> Results { get; set; }
+}

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/AuthenticationService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/AuthenticationService.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Extensions.Options;
+
+using Umbraco.Cms.Core.Services;
+using Umbraco.Forms.Integrations.Crm.Hubspot.Configuration;
+
+namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services;
+
+public class AuthenticationService : IAuthenticationService
+{
+    private readonly HubspotSettings _settings;
+
+    private readonly IKeyValueService _keyValueService;
+
+	public AuthenticationService(IOptions<HubspotSettings> options, IKeyValueService keyValueService)
+	{
+		_settings= options.Value;
+        _keyValueService= keyValueService;
+	}
+
+    public AuthenticationDetail GetDetails()
+    {
+        var authentication = new AuthenticationDetail();
+        if (TryGetApiKey(out string apiKey))
+        {
+            authentication.ApiKey = apiKey;
+        }
+        else if (TryGetPrivateAccessToken(out string privateAccessToken))
+        {
+            authentication.PrivateAccessToken = privateAccessToken;
+        }
+        else if (TryGetSavedRefreshToken(out string refreshToken))
+        {
+            authentication.RefreshToken = refreshToken;
+        }
+
+        return authentication;
+    }
+
+    private bool TryGetApiKey(out string apiKey)
+    {
+        apiKey = _settings.ApiKey;
+
+        return !string.IsNullOrEmpty(apiKey);
+    }
+
+    private bool TryGetPrivateAccessToken(out string accessToken)
+    {
+        accessToken = _settings.PrivateAccessToken;
+
+        return !string.IsNullOrEmpty(accessToken);
+    }
+
+    private bool TryGetSavedRefreshToken(out string refreshToken)
+    {
+        refreshToken = _keyValueService.GetValue(Constants.RefreshTokenDatabaseKey);
+        return !string.IsNullOrEmpty(refreshToken);
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/IAuthenticationService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/IAuthenticationService.cs
@@ -1,0 +1,7 @@
+﻿
+namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services;
+
+public interface IAuthenticationService
+{
+    AuthenticationDetail GetDetails();
+}

--- a/src/Umbraco.Forms.Integrations.Testsite.V10/Constants.cs
+++ b/src/Umbraco.Forms.Integrations.Testsite.V10/Constants.cs
@@ -1,0 +1,8 @@
+﻿namespace Umbraco.Forms.Integrations.Testsite.V10;
+
+public class Constants
+{
+    public const string HubspotClient = "HubspotClient";
+
+    public const string HubspotSettingsPath = "Umbraco:Forms:Integrations:Crm:Hubspot:Settings";
+}

--- a/src/Umbraco.Forms.Integrations.Testsite.V10/Controllers/ContactsController.cs
+++ b/src/Umbraco.Forms.Integrations.Testsite.V10/Controllers/ContactsController.cs
@@ -1,0 +1,156 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+using Umbraco.Cms.Web.Common.Controllers;
+using Umbraco.Forms.Integrations.Testsite.V10.Models;
+
+namespace Umbraco.Forms.Integrations.Testsite.V10.Controllers;
+
+[Route("umbraco/api/hubspot/v1/contacts")]
+public class ContactsController : UmbracoApiController
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<ContactsController> _logger;
+
+    protected readonly string PrivateAccessToken;
+
+    public ContactsController(IConfiguration configuration, IHttpClientFactory httpClientFactory, ILogger<ContactsController> logger)
+	{
+		_httpClientFactory = httpClientFactory;
+        _logger = logger;
+
+        PrivateAccessToken = configuration.GetSection(Constants.HubspotSettingsPath)["PrivateAccessToken"];
+	}
+
+    /// <summary>
+    /// Gets the list of contacts from HubSpot.
+    /// </summary>
+    /// <returns>A list of contacts or Unauthorized, BadRequest status codes.</returns>
+    [HttpGet]
+    [ServiceFilter(typeof(HubspotPrivateAccessTokenFilterAttribute))]
+    public async Task<IActionResult> Get()
+    {
+        var client = _httpClientFactory.CreateClient(Constants.HubspotClient);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrivateAccessToken);
+
+        var response = await client.GetAsync("objects/contacts");
+        if(!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Failed to fetch contacts from HubSpot API. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+            return BadRequest(response.ReasonPhrase);
+        }
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return Ok(JsonSerializer.Deserialize<ContactResponse>(responseContent));
+    }
+
+    /// <summary>
+    /// Get a contact by id.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns>The contact details or Unauthorized, BadRequest status codes.</returns>
+    [HttpGet]
+    [ServiceFilter(typeof(HubspotPrivateAccessTokenFilterAttribute))]
+    [Route("{id}")]
+    public async Task<IActionResult> Get(string id)
+    {
+        var client = _httpClientFactory.CreateClient(Constants.HubspotClient);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrivateAccessToken);
+
+        var response = await client.GetAsync($"objects/contacts/{id}");
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Failed to fetch contact with id: {id} from HubSpot API. {StatusCode} {ReasonPhrase}", id, response.StatusCode, response.ReasonPhrase);
+            return BadRequest(response.ReasonPhrase);
+        }
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        return Ok(JsonSerializer.Deserialize<ContactDetail>(responseContent));
+    }
+
+    /// <summary>
+    /// Create new contact.
+    /// </summary>
+    /// <param name="contact"></param>
+    /// <returns>Created, Unauthorized or BadRequest status codes.</returns>
+    [HttpPost]
+    [ServiceFilter(typeof(HubspotPrivateAccessTokenFilterAttribute))]
+    public async Task<IActionResult> Create([FromBody] ContactDetail contact)
+    {
+        var client = _httpClientFactory.CreateClient(Constants.HubspotClient);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrivateAccessToken);
+
+        var response = await client.PostAsync("objects/contacts", 
+            new StringContent(JsonSerializer.Serialize(contact), Encoding.UTF8, "application/json"));
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Failed to create contact. {StatusCode} {ReasonPhrase}", response.StatusCode, response.ReasonPhrase);
+            return BadRequest(response.ReasonPhrase);
+        }
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var contactDetail = JsonSerializer.Deserialize<ContactDetail>(responseContent);
+        if (contactDetail != null)
+        {
+            contact.Id = contactDetail.Id;
+        }
+
+        return Created($"objects/contacts/{(contact != null ? contact.Id : string.Empty)}", contact);
+    }
+
+    /// <summary>
+    /// Update contact details.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="contact"></param>
+    /// <returns>Success, Unauthorized or BadRequest status codes.</returns>
+    [HttpPatch]
+    [ServiceFilter(typeof(HubspotPrivateAccessTokenFilterAttribute))]
+    [Route("{id}")]
+    public async Task<IActionResult> Update(string id, [FromBody] ContactDetail contact)
+    {
+        var client = _httpClientFactory.CreateClient(Constants.HubspotClient);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrivateAccessToken);
+
+        var response = await client.PatchAsync($"objects/contacts/{id}", 
+            new StringContent(JsonSerializer.Serialize(contact), Encoding.UTF8, "application/json"));
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Failed to update contact with id: {id} from HubSpot API. {StatusCode} {ReasonPhrase}", id, response.StatusCode, response.ReasonPhrase);
+            return BadRequest(response.ReasonPhrase);
+        }
+
+        return Ok();
+    }
+
+    /// <summary>
+    /// Delete contact.
+    /// </summary>
+    /// <param name="id"></param>
+    /// <returns>No Content, Unauthorized or BadRequest status codes.</returns>
+    [HttpDelete]
+    [ServiceFilter(typeof(HubspotPrivateAccessTokenFilterAttribute))]
+    [Route("{id}")]
+    public async Task<IActionResult> Delete(string id)
+    {
+        var client = _httpClientFactory.CreateClient(Constants.HubspotClient);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrivateAccessToken);
+
+        var response = await client.DeleteAsync($"objects/contacts/{id}");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Failed to delete contact with id: {id} from HubSpot API. {StatusCode} {ReasonPhrase}", id, response.StatusCode, response.ReasonPhrase);
+            return BadRequest(response.ReasonPhrase);
+        }
+
+        return NoContent();
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Testsite.V10/Filters/HubspotPrivateAccessTokenFilterAttribute.cs
+++ b/src/Umbraco.Forms.Integrations.Testsite.V10/Filters/HubspotPrivateAccessTokenFilterAttribute.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Umbraco.Forms.Integrations.Testsite.V10;
+
+public class HubspotPrivateAccessTokenFilterAttribute : IActionFilter
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<HubspotPrivateAccessTokenFilterAttribute> _logger;
+
+    public HubspotPrivateAccessTokenFilterAttribute(
+        IConfiguration configuration,
+        ILogger<HubspotPrivateAccessTokenFilterAttribute> logger)
+    {
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+    }
+
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+        var privateAccessToken = _configuration.GetSection(Constants.HubspotSettingsPath)["PrivateAccessToken"];
+        if(string.IsNullOrEmpty(privateAccessToken))
+        {
+            const string message = "Cannot access HubSpot API. Private Access Token is either missing or invalid.";
+            _logger.LogInformation(message);
+            context.Result = new UnauthorizedObjectResult(message);
+        }
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Testsite.V10/HubspotComposer.cs
+++ b/src/Umbraco.Forms.Integrations.Testsite.V10/HubspotComposer.cs
@@ -1,0 +1,20 @@
+﻿using System.Net.Http.Headers;
+
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.Forms.Integrations.Testsite.V10;
+
+public class HubspotComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.Services
+            .AddHttpClient(Constants.HubspotClient, client =>
+            {
+                client.BaseAddress = new Uri("https://api.hubapi.com/crm/v3/");
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            });
+
+        builder.Services.AddScoped<HubspotPrivateAccessTokenFilterAttribute>();
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Testsite.V10/Models/Contact.cs
+++ b/src/Umbraco.Forms.Integrations.Testsite.V10/Models/Contact.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Umbraco.Forms.Integrations.Testsite.V10.Models;
+
+public class Contact
+{
+    public Contact(string firstName, string lastName, string email, string company)
+    {
+        FirstName = firstName;
+        LastName = lastName;
+        Email = email;
+        Company = company;
+    }
+
+    [JsonPropertyName("firstname")]
+    public string FirstName { get; set; }
+
+    [JsonPropertyName("lastname")]
+    public string LastName { get; set; }
+
+    [JsonPropertyName("email")]
+    public string Email { get; set; }
+
+    [JsonPropertyName("company")]
+    public string Company { get; set; }
+}

--- a/src/Umbraco.Forms.Integrations.Testsite.V10/Models/ContactDetail.cs
+++ b/src/Umbraco.Forms.Integrations.Testsite.V10/Models/ContactDetail.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Umbraco.Forms.Integrations.Testsite.V10.Models;
+
+public class ContactDetail
+{
+    public ContactDetail(string id, Contact properties)
+    {
+        Id = id;
+        Properties = properties;
+    }
+
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("properties")]
+    public Contact Properties { get; set; }
+}

--- a/src/Umbraco.Forms.Integrations.Testsite.V10/Models/ContactResponse.cs
+++ b/src/Umbraco.Forms.Integrations.Testsite.V10/Models/ContactResponse.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Umbraco.Forms.Integrations.Testsite.V10.Models;
+
+public class ContactResponse
+{
+    [JsonPropertyName("results")]
+    public List<ContactDetail> Results { get; set; }
+
+    public ContactResponse(List<ContactDetail> results)
+    {
+        Results = results;
+    }
+}


### PR DESCRIPTION
Current PR contains two approaches to implement CRUD operations against contacts from HubSpot. 

My initial approach was to handle them as part of the package reusing the existing implementations, but after our discussion, I have moved the components to the sample test site. For this use case, the access to the HubSpot API is handled using `Private Access Tokens`.

Here is a breakdown of the components:

1.  `ContactsController` - `UmbracoApiController` for handling HTTP requests using this endpoint: `umbraco/api/hubspot/v1/contacts`. Resources are handled using GET/POST/PATCH/DELETE requests.
2.  `HubspotPrivateAccessTokenFilterAttribute` - action filter for validating the private access token before the action gets executed. Returns `Unauthorized` is the setting is missing.
3. Models for working with the HubSpot contact resource.
4. `HubspotComposer` for registering the HTTP client and the action filter.
5. Constants object.