### PR TITLE
Add HubSpot specific string return values.

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Extensions/RecordFieldExtensions.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Extensions/RecordFieldExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Umbraco.Forms.Core.Data.Helpers;
+using Umbraco.Forms.Core.Persistence.Dtos;
+
+namespace Umbraco.Forms.Integrations.Crm.Hubspot.Extensions;
+
+public static class RecordFieldExtensions
+{
+    public static string ValuesAsHubspotString(this RecordField recordField, bool escaped = true)
+    {
+        if (!recordField.HasValue())
+        {
+            return string.Empty;
+        }
+
+        if (!escaped)
+        {
+            return string.Join(", ", recordField.Values.ToArray());
+        }
+
+        return string.Join(", ", recordField.Values.ConvertAll((object input) => JsonHelper.EscapeStringValue(input.ToString())).ToArray());
+    }
+}

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Extensions/RecordFieldExtensions.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Extensions/RecordFieldExtensions.cs
@@ -14,9 +14,9 @@ public static class RecordFieldExtensions
 
         if (!escaped)
         {
-            return string.Join(", ", recordField.Values.ToArray());
+            return string.Join(";", recordField.Values.ToArray());
         }
 
-        return string.Join(", ", recordField.Values.ConvertAll((object input) => JsonHelper.EscapeStringValue(input.ToString())).ToArray());
+        return string.Join(";", recordField.Values.ConvertAll((object input) => JsonHelper.EscapeStringValue(input.ToString())).ToArray());
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
@@ -160,7 +160,7 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                 var recordField = record.GetRecordField(Guid.Parse(fieldId));
                 if (recordField != null)
                 {
-                    var value = recordField.ValuesAsString(false);
+                    var value = recordField.ValuesAsHubspotString(false);
 
                     propertiesRequestV1.Properties.Add(new PropertiesRequestV1.PropertyValue(mapping.HubspotField, value));
                     propertiesRequestV3.Properties.Add(mapping.HubspotField, value);
@@ -218,7 +218,8 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                     }
                     else
                     {
-                        _logger.LogError("Error creating a HubSpot contact.");
+                        var responseContent = await response.Content.ReadAsStringAsync();
+                        _logger.LogError($"Error creating a HubSpot contact: {responseContent}");
                         return CommandResult.Failed;
                     }
                 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Umbraco.Forms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Umbraco.Forms.Integrations.Crm.Hubspot.csproj
@@ -11,7 +11,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Forms.Integrations/tree/main-v10/src/Umbraco.Forms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Forms.Integrations</RepositoryUrl>
-		<Version>3.2.0</Version>
+		<Version>3.3.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR is a result of the issue reported [here](https://github.com/umbraco/Umbraco.Cms.Integrations/issues/126), where _HubSpot_ contacts were not saved on form submission.

For this particular use case, investigations revealed that specific field types (in this case _Multiple checkboxes_) require to values to be provided in a string, separated by semicolons - `;`. Since the form record's values in Umbraco are returned as a comma - `, ` - separated string, a `400 Bad Request` error was returned by HubSpot API and the contact was not saved.

To address this, I have created a new extension method called `ValuesAsHubspotString`, a clone of `ValuesAsString`, but replaced `, ` with `;`.

Additionally I am logging the service response if unsuccessful to have the Hubspot service response logged.

