### PR TITLE
Add feature to allow contact field value append.

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspot-field-mapper-template.html
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspot-field-mapper-template.html
@@ -24,6 +24,7 @@
             <div class="umb-forms-mapping-header">
                 <div class="umb-forms-mapping-field -no-margin-left">Form Field</div>
                 <div class="umb-forms-mapping-field">Hubspot Field</div>
+                <div class="umb-forms-mapping-field text-center">Append when updating values</div>
                 <div class="umb-forms-mapping-remove -no-margin-right"></div>
             </div>
 
@@ -44,6 +45,14 @@
                                 ng-model="mapping.hubspotField"
                                 ng-change="vm.stringifyValue()">
                         </select>
+                    </div>
+
+                    <div class="umb-forms-mapping-field flex justify-center">
+                        <umb-checkbox name="chkAppend"
+                                      value="mapping.appendValue"
+                                      model="mapping.appendValue"
+                                      on-change="vm.stringifyValue()">
+                        </umb-checkbox>
                     </div>
 
                     <div class="umb-forms-mapping-remove -no-margin-right">

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspot-field-mapper-template.html
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspot-field-mapper-template.html
@@ -20,11 +20,10 @@
         </div>
 
         <div class="umb-forms-mappings mt2" ng-show="vm.mappings.length > 0 && vm.hubspotFields.length > 0">
-
             <div class="umb-forms-mapping-header">
                 <div class="umb-forms-mapping-field -no-margin-left">Form Field</div>
                 <div class="umb-forms-mapping-field">Hubspot Field</div>
-                <div class="umb-forms-mapping-field text-center">Append when updating values</div>
+                <div ng-if="vm.allowContactUpdate" class="umb-forms-mapping-field text-center">Append when updating values</div>
                 <div class="umb-forms-mapping-remove -no-margin-right"></div>
             </div>
 
@@ -47,7 +46,7 @@
                         </select>
                     </div>
 
-                    <div class="umb-forms-mapping-field flex justify-center">
+                    <div ng-if="vm.allowContactUpdate" class="umb-forms-mapping-field flex justify-center">
                         <umb-checkbox name="chkAppend"
                                       value="mapping.appendValue"
                                       model="mapping.appendValue"

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspotfields.component.js
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspotfields.component.js
@@ -53,7 +53,7 @@ function HubSpotFieldsController($scope, $routeParams, umbracoFormsIntegrationsC
 
     vm.$onInit = function () {
 
-        vm.allowContactUpdate = Umbraco.Sys.ServerVariables.umbracoPlugins.umbracoFormsIntegrationsCrmHubspotAllowContactUpdate;
+        vm.allowContactUpdate = Umbraco.Sys.ServerVariables.umbracoPlugins.umbracoFormsIntegrationsCrmHubspot.allowContactUpdate;
 
         if (!vm.setting.value) {
             vm.mappings = [];

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspotfields.component.js
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspotfields.component.js
@@ -53,10 +53,12 @@ function HubSpotFieldsController($scope, $routeParams, umbracoFormsIntegrationsC
 
     vm.$onInit = function () {
 
+        vm.allowContactUpdate = Umbraco.Sys.ServerVariables.umbracoPlugins.umbracoFormsIntegrationsCrmHubspotAllowContactUpdate;
+
         if (!vm.setting.value) {
             vm.mappings = [];
         } else {
-            vm.getParsedMappings();
+            vm.mappings = parseMappings(vm.setting.value);
         }
 
         umbracoFormsIntegrationsCrmHubspotResource.isAuthorizationConfigured().then(function (response) {
@@ -192,9 +194,9 @@ function HubSpotFieldsController($scope, $routeParams, umbracoFormsIntegrationsC
         vm.setting.value = JSON.stringify(vm.mappings);
     };
 
-    vm.getParsedMappings = function () {
-        var mappings = JSON.parse(vm.setting.value);
-        vm.mappings = mappings.map(mappingObj => {
+    function parseMappings(settingValue) {
+        var mappings = JSON.parse(settingValue);
+        return mappings.map(mappingObj => {
             if (mappingObj.appendValue === undefined) {
                 mappingObj.appendValue = false;
             }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspotfields.component.js
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/App_Plugins/UmbracoForms.Integrations/Crm/Hubspot/hubspotfields.component.js
@@ -56,7 +56,7 @@ function HubSpotFieldsController($scope, $routeParams, umbracoFormsIntegrationsC
         if (!vm.setting.value) {
             vm.mappings = [];
         } else {
-            vm.mappings = JSON.parse(vm.setting.value);
+            vm.getParsedMappings();
         }
 
         umbracoFormsIntegrationsCrmHubspotResource.isAuthorizationConfigured().then(function (response) {
@@ -178,7 +178,8 @@ function HubSpotFieldsController($scope, $routeParams, umbracoFormsIntegrationsC
         // Add new empty object into the mappings array.
         vm.mappings.push({
             formField: "",
-            hubspotField: ""
+            hubspotField: "",
+            appendValue: false
         });
     };
 
@@ -190,4 +191,14 @@ function HubSpotFieldsController($scope, $routeParams, umbracoFormsIntegrationsC
     vm.stringifyValue = function () {
         vm.setting.value = JSON.stringify(vm.mappings);
     };
+
+    vm.getParsedMappings = function () {
+        var mappings = JSON.parse(vm.setting.value);
+        vm.mappings = mappings.map(mappingObj => {
+            if (mappingObj.appendValue === undefined) {
+                mappingObj.appendValue = false;
+            }
+            return mappingObj;
+        });
+    }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/HubspotServerVariablesParsingHandler.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/HubspotServerVariablesParsingHandler.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Extensions;
+using Umbraco.Forms.Integrations.Crm.Hubspot.Configuration;
 using Umbraco.Forms.Integrations.Crm.Hubspot.Controllers;
 
 namespace Umbraco.Forms.Integrations.Crm.Hubspot
@@ -15,12 +16,15 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly LinkGenerator _linkGenerator;
+        private readonly HubspotSettings _settings;
 
-        public HubspotServerVariablesParsingHandler(IHttpContextAccessor httpContextAccessor, LinkGenerator linkGenerator)
+        public HubspotServerVariablesParsingHandler(IHttpContextAccessor httpContextAccessor, LinkGenerator linkGenerator, IOptions<HubspotSettings> options)
         {
             _httpContextAccessor = httpContextAccessor;
 
-            _linkGenerator = linkGenerator; 
+            _linkGenerator = linkGenerator;
+
+            _settings = options.Value;
         }
 
         public void Handle(ServerVariablesParsingNotification notification)
@@ -50,6 +54,12 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot
 
             umbracoUrls["umbracoFormsIntegrationsCrmHubspotBaseUrl"] =
                 _linkGenerator.GetUmbracoApiServiceBaseUrl<HubspotController>(controller => controller.GetAllProperties());
+
+            if (serverVars.ContainsKey("umbracoPlugins"))
+            {
+                var umbracoPlugins = (Dictionary<string, object>)serverVars["umbracoPlugins"];
+                umbracoPlugins.Add("umbracoFormsIntegrationsCrmHubspotAllowContactUpdate", _settings.AllowContactUpdate);
+            }
 
         }
     }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/HubspotServerVariablesParsingHandler.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/HubspotServerVariablesParsingHandler.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
-
+using System.Runtime.Serialization;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Extensions;
@@ -58,9 +58,19 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot
             if (serverVars.ContainsKey("umbracoPlugins"))
             {
                 var umbracoPlugins = (Dictionary<string, object>)serverVars["umbracoPlugins"];
-                umbracoPlugins.Add("umbracoFormsIntegrationsCrmHubspotAllowContactUpdate", _settings.AllowContactUpdate);
+                umbracoPlugins.Add("umbracoFormsIntegrationsCrmHubspot", new ClientSideConfiguration
+                {
+                    AllowContactUpdate = _settings.AllowContactUpdate
+                });
             }
 
+        }
+
+        [DataContract]
+        internal sealed class ClientSideConfiguration
+        {
+            [DataMember(Name = "allowContactUpdate")]
+            public bool AllowContactUpdate { get; set; }
         }
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/MappedProperty.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Models/MappedProperty.cs
@@ -9,5 +9,8 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Models
 
         [JsonProperty(PropertyName = "hubspotField")]
         public string HubspotField { get; set; }
+
+        [JsonProperty(PropertyName = "appendValue")]
+        public bool AppendValue { get; set; }
     }
 }

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
@@ -160,7 +160,9 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                 var recordField = record.GetRecordField(Guid.Parse(fieldId));
                 if (recordField != null)
                 {
-                    var value = recordField.ValuesAsHubspotString(false);
+                    var value = _settings.AllowContactUpdate && mapping.AppendValue
+                        ? ";" + recordField.ValuesAsHubspotString(false)
+                        : recordField.ValuesAsHubspotString(false);
 
                     propertiesRequestV1.Properties.Add(new PropertiesRequestV1.PropertyValue(mapping.HubspotField, value));
                     propertiesRequestV3.Properties.Add(mapping.HubspotField, value);

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Umbraco.Forms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Umbraco.Forms.Integrations.Crm.Hubspot.csproj
@@ -11,7 +11,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Forms.Integrations/tree/main-v10/src/Umbraco.Forms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Forms.Integrations</RepositoryUrl>
-		<Version>3.2.1</Version>
+		<Version>3.3.0</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR contains a feature that allows the append of values to a HubSpot contact field. 

This was raised by an agency building an integration with HubSpot, specifying that for a `Multiple Checkboxes` HubSpot field, they would prefer to be able to append the field values, instead of replacing.

To achieve this behavior, I have added a new property to the mappings component, called `AppendValue` that will specify whether for that specific field, if this setting is added: `AllowContactUpdate = true`, the value wil be appended. Appending a value is possible in HubSpot by adding a semi-colon `;` before the actual values. I used this [forum thread](https://community.hubspot.com/t5/APIs-Integrations/Append-to-a-contact-property/m-p/340941/highlight/true#M33319) for reference.

A small demo of the use case can be viewed [here](https://us02web.zoom.us/clips/share/A2F3MSBm2iXkNnyu_yKtvA5MQCI5Pz-Tzob5lL0hXUn6Y5KVRA).

Next step after approval is to move this for v8 version of the package as well.
