### PR TITLE
Use correct wording at HubSpot

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/HubspotWorkflow.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/HubspotWorkflow.cs
@@ -22,8 +22,8 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot
             _contactService = contactService;
 
             Id = new Guid("c47ef1ef-22b1-4b9d-acf6-f57cb8961550");
-            Name = "Save Contact to Hubspot";
-            Description = "Form submissions are sent to Hubspot CRM";
+            Name = "Save Contact to HubSpot";
+            Description = "Form submissions are sent to HubSpot CRM";
             Icon = "icon-handshake";
             Group = "CRM";
         }
@@ -37,7 +37,7 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot
             var fieldMappings = JsonConvert.DeserializeObject<List<MappedProperty>>(fieldMappingsRawJson);
             if (fieldMappings.Count == 0)
             {
-                _logger.Warn<HubspotWorkflow>("Workflow {WorkflowName}: Missing Hubspot field mappings for workflow for the form {FormName} ({FormId})", Workflow.Name, e.Form.Name, e.Form.Id);
+                _logger.Warn<HubspotWorkflow>("Workflow {WorkflowName}: Missing HubSpot field mappings for workflow for the form {FormName} ({FormId})", Workflow.Name, e.Form.Name, e.Form.Id);
                 return WorkflowExecutionStatus.NotConfigured;
             }
 

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Services/HubspotContactService.cs
@@ -146,7 +146,7 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                 return CommandResult.NotConfigured;
             }
 
-            // Map data from the workflow setting Hubspot fields
+            // Map data from the workflow setting HubSpot fields
             // From the form field values submitted for this form submission
             var propertiesRequestV1 = new PropertiesRequestV1();
             var propertiesRequestV3 = new PropertiesRequestV3();
@@ -164,7 +164,7 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                     propertiesRequestV1.Properties.Add(new PropertiesRequestV1.PropertyValue(mapping.HubspotField, value));
                     propertiesRequestV3.Properties.Add(mapping.HubspotField, value);
 
-                    // TODO: What about different field types in forms & Hubspot that are not simple text ones?
+                    // TODO: What about different field types in forms & HubSpot that are not simple text ones?
 
                     // "Email" appears to be a special form field used for uniqueness checks, so we can safely look it up by name.
                     if (mapping.HubspotField.ToLowerInvariant() == "email")
@@ -189,7 +189,7 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                 }
             }
 
-            // POST data to hubspot
+            // POST data to HubSpot
             // https://api.hubapi.com/crm/v3/objects/contacts?hapikey=YOUR_HUBSPOT_API_KEY
             var requestUrl = $"{CrmV3ApiBaseUrl}objects/contacts";
             var httpMethod = HttpMethod.Post;
@@ -213,7 +213,7 @@ namespace Umbraco.Forms.Integrations.Crm.Hubspot.Services
                     var retryResult = await HandleFailedRequest(response.StatusCode, requestUrl, httpMethod, authenticationDetails, propertiesRequestV3, JsonContentType);
                     if (retryResult.Success)
                     {
-                        _logger.Info<HubspotContactService>($"Hubspot contact record created from record {record.UniqueId}.");
+                        _logger.Info<HubspotContactService>($"HubSpot contact record created from record {record.UniqueId}.");
                         return CommandResult.Success;
                     }
                     else

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/docs/readme.md
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/docs/readme.md
@@ -1,4 +1,4 @@
-# Hubspot with Umbraco Forms
+# HubSpot with Umbraco Forms
 With this integration, you can connect HubSpot CRM with Umbraco Forms and store information  that your Umbraco website visitors submit, as contacts in your HubSpot CRM platform!
 
 More specifically the integration adds a new workflow option when creating or editing a form via the back-office. When the form is added to your webpage, filled out, and submitted the information can be seen via your HubSpot account dashboard. 

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/docs/readme.md
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/docs/readme.md
@@ -1,11 +1,11 @@
 # Hubspot with Umbraco Forms
-With this integration, you can connect Hubspot CRM with Umbraco Forms and store information  that your Umbraco website visitors submit, as contacts in your Hubspot CRM platform!
+With this integration, you can connect HubSpot CRM with Umbraco Forms and store information  that your Umbraco website visitors submit, as contacts in your HubSpot CRM platform!
 
 More specifically the integration adds a new workflow option when creating or editing a form via the back-office. When the form is added to your webpage, filled out, and submitted the information can be seen via your HubSpot account dashboard. 
 
 **Customizing Umbraco Forms:**
 
-Within Umbraco Forms, we provide a custom workflow that sends the submitted information to Hubspot CRM where it is used to create or update a contact record. 
+Within Umbraco Forms, we provide a custom workflow that sends the submitted information to HubSpot CRM where it is used to create or update a contact record. 
 
 Workflows within Umbraco Forms are processes that run after a form is submitted to allow you to do more with the provided information than just store it in the database for subsequent review in the back-office. Out of the box, you can configure operations like sending an email with the information provided, but workflows are also something you can build yourself for the specific needs of your application. 
 

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/package.xml
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/package.xml
@@ -21,7 +21,7 @@
       <contributor>Warren Buckley</contributor>
       <contributor>Andy Butland</contributor>
     </contributors>
-    <readme><![CDATA[An extension for Umbraco Forms to add support for submitting data to Hubspot]]></readme>
+    <readme><![CDATA[An extension for Umbraco Forms to add support for submitting data to HubSpot]]></readme>
   </info>
   <files>
     <folder path="App_Plugins/UmbracoForms.Integrations/Crm/Hubspot" orgPath="App_Plugins/UmbracoForms.Integrations/Crm/Hubspot" />


### PR DESCRIPTION
The wording of Hubspot should be `HubSpot`.

The classes, properties etc. could eventually be updated, but isn't crucial.
