### PR TITLE
Feature/shopify outh

### DIFF
--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/OAuthProxyController.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/OAuthProxyController.cs
@@ -63,10 +63,10 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
 
             // Shopify's endpoint (and potentially others in future) for retrieving the access token is directly coupled with the shop's name.
             // As a result the address of the client needs to be updated with the request header value for the name of the shop.
-            var serviceAddressReplaceHeader = Request.Headers.FirstOrDefault(p => p.Key.Contains(ServiceAddressReplacePrefixHeaderKey));
+            var serviceAddressReplaceHeader = Request.Headers.FirstOrDefault(p => p.Key.ToLowerInvariant().Contains(ServiceAddressReplacePrefixHeaderKey));
             if (!serviceAddressReplaceHeader.Equals(default(KeyValuePair<string, StringValues>)) && httpClient.BaseAddress != null)
             {
-                var replaceKey = serviceAddressReplaceHeader.Key.Replace(ServiceAddressReplacePrefixHeaderKey, string.Empty);
+                var replaceKey = serviceAddressReplaceHeader.Key.ToLowerInvariant().Replace(ServiceAddressReplacePrefixHeaderKey, string.Empty);
 
                 var baseAddress = httpClient.BaseAddress.ToString().Replace($"{replaceKey}", serviceAddressReplaceHeader.Value);
                 httpClient.BaseAddress = new Uri(baseAddress);

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/ShopifyComplianceController.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/ShopifyComplianceController.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
+{
+    [ApiController]
+    public class ShopifyComplianceController : Controller
+    {
+        /// <summary>
+        /// Handles customer data requests from Shopify
+        /// </summary>
+        /// <returns></returns>
+        [HttpPost]
+        [Route("/shopify-compliance/v1/customer/data-request")]
+        public IActionResult CustomerDataRequest() => Ok();
+
+        /// <summary>
+        /// Handles customer data erasure requests from Shopify
+        /// </summary>
+        /// <returns></returns>
+        [HttpPost]
+        [Route("/shopify-compliance/v1/customer/data-redact")]
+        public IActionResult CustomerDataRedact() => Ok();
+
+        /// <summary>
+        /// Handles shop data erasure requests from Shopify
+        /// </summary>
+        /// <returns></returns>
+        [HttpPost]
+        [Route("/shopify-compliance/v1/shop/data-redact")]
+        public IActionResult ShopDataRedact() => Ok();
+    }
+}


### PR DESCRIPTION
Current PR adds a couple of updates in support of the Shopify's OAuth flow and Shopify Marketplace app release.

1. Updated the retrieval of the shop's name header value to ensure the correct path update with store name.
2. Added blank endpoints for compliance purposes, as part of the final steps towards getting the Umbraco app listed on the Shopify Marketplace.
These requirements are listed [here](https://shopify.dev/docs/apps/build/privacy-law-compliance) and per confirmation with Shopify dev team we just need to support the following:
- accept `POST` requests
- return a `200 - OK` status message
- accept a `content-type=application/json` header

Once confirmed I will publish the updates and try publishing the app again.