### PR TITLE
Shopify header signature validation

### DIFF
--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/ShopifyComplianceController.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/ShopifyComplianceController.cs
@@ -3,8 +3,8 @@ using Umbraco.Cms.Integrations.OAuthProxy.Filters;
 
 namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
 {
-    [ApiController]
-    public class ShopifyComplianceController : Controller
+	[ApiController]
+	public class ShopifyComplianceController : Controller
     {
         /// <summary>
         /// Handles customer data requests from Shopify
@@ -12,8 +12,8 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
         /// <returns></returns>
         [HttpPost]
         [Route("/shopify-compliance/v1/customer/data-request")]
-        [SignatureValidation]
-        public IActionResult CustomerDataRequest() => Ok();
+		[SignatureValidation]
+		public IActionResult CustomerDataRequest() => Ok();
 
         /// <summary>
         /// Handles customer data erasure requests from Shopify
@@ -21,8 +21,8 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
         /// <returns></returns>
         [HttpPost]
         [Route("/shopify-compliance/v1/customer/data-redact")]
-        [SignatureValidation]
-        public IActionResult CustomerDataRedact() => Ok();
+		[SignatureValidation]
+		public IActionResult CustomerDataRedact() => Ok();
 
         /// <summary>
         /// Handles shop data erasure requests from Shopify
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
         /// <returns></returns>
         [HttpPost]
         [Route("/shopify-compliance/v1/shop/data-redact")]
-        [SignatureValidation]
-        public IActionResult ShopDataRedact() => Ok();
+		[SignatureValidation]
+		public IActionResult ShopDataRedact() => Ok();
     }
 }

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/ShopifyComplianceController.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/ShopifyComplianceController.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Integrations.OAuthProxy.Filters;
 
 namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
 {
-    [ApiController]
+	[ApiController]
     public class ShopifyComplianceController : Controller
     {
         /// <summary>
@@ -11,6 +12,7 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
         /// <returns></returns>
         [HttpPost]
         [Route("/shopify-compliance/v1/customer/data-request")]
+        [SignatureValidation]
         public IActionResult CustomerDataRequest() => Ok();
 
         /// <summary>
@@ -19,6 +21,7 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
         /// <returns></returns>
         [HttpPost]
         [Route("/shopify-compliance/v1/customer/data-redact")]
+        [SignatureValidation]
         public IActionResult CustomerDataRedact() => Ok();
 
         /// <summary>
@@ -27,6 +30,7 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
         /// <returns></returns>
         [HttpPost]
         [Route("/shopify-compliance/v1/shop/data-redact")]
+        [SignatureValidation]
         public IActionResult ShopDataRedact() => Ok();
     }
 }

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/ShopifyComplianceController.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Controllers/ShopifyComplianceController.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Integrations.OAuthProxy.Filters;
 
 namespace Umbraco.Cms.Integrations.OAuthProxy.Controllers
 {
-	[ApiController]
+    [ApiController]
     public class ShopifyComplianceController : Controller
     {
         /// <summary>

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Filters/SignatureValidationAttribute.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Filters/SignatureValidationAttribute.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Filters
 	{
 		private const string HeaderKey = "X-Shopify-Hmac-Sha256";
 
-        public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+		public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
 		{
 			var appSettings = context.HttpContext.RequestServices.GetService<IOptions<AppSettings>>().Value;
 

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Filters/SignatureValidationAttribute.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Filters/SignatureValidationAttribute.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Cms.Integrations.OAuthProxy.Configuration;
+
+namespace Umbraco.Cms.Integrations.OAuthProxy.Filters
+{
+	public class SignatureValidationAttribute : ActionFilterAttribute
+	{
+		private const string HeaderKey = "X-Shopify-Hmac-Sha256";
+
+        public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+		{
+			var appSettings = context.HttpContext.RequestServices.GetService<IOptions<AppSettings>>().Value;
+
+			var hmacHeaderValues = context.HttpContext.Request.Headers
+				.FirstOrDefault(kvp => kvp.Key.Equals(HeaderKey, StringComparison.OrdinalIgnoreCase)).Value;
+
+			if (hmacHeaderValues.Count == 0)
+			{
+				context.Result = new UnauthorizedResult();
+				return;
+			}
+
+			string hmacHeader = hmacHeaderValues.First();
+
+			HMACSHA256 hmac = new HMACSHA256(Encoding.UTF8.GetBytes(appSettings.ShopifyClientSecret));
+
+			var bodyStream = new StreamReader(context.HttpContext.Request.Body);
+			string requestBody = await bodyStream.ReadToEndAsync();
+			string hash = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(requestBody)));
+
+			if (hash != hmacHeader)
+			{
+				context.Result = new UnauthorizedResult();
+				return;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Current PR contains a feature for Shopify OAuth that validates a custom header to ensure that the request is authorized.

As part of the submission process, Shopify requires that all webhook requests regarding compliance are validated based on the value of the `X-Shopify-Hmac-Sha256` request header. The value received is compared with an `HMAC256` hash of the client secret, and Shopify expects a `401-Unauthorized` response if the two don't match.

To support this, I've added a custom action filter that intercepts the request and validates the header value.