### PR TITLE
Handle invalid access as Unauthorized

### DIFF
--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Api/Management/Controllers/GetFormPropertiesByIdController.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Api/Management/Controllers/GetFormPropertiesByIdController.cs
@@ -17,11 +17,13 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier.Api.Management.Controller
 
         [HttpGet("forms/{id}")]
         [ProducesResponseType(typeof(List<Dictionary<string, string>>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public IActionResult GetFormPropertiesById(string id)
         {
             var emptyList = new List<Dictionary<string, string>>();
 
-            if (!IsAccessValid()) return Ok(emptyList);
+            if (!IsAccessValid())
+                return Unauthorized();
 
             var form = ZapierFormService.GetById(id);
 

--- a/src/Umbraco.Forms.Integrations.Automation.Zapier/Api/Management/Controllers/GetFormsController.cs
+++ b/src/Umbraco.Forms.Integrations.Automation.Zapier/Api/Management/Controllers/GetFormsController.cs
@@ -18,9 +18,11 @@ namespace Umbraco.Forms.Integrations.Automation.Zapier.Api.Management.Controller
 
         [HttpGet("forms")]
         [ProducesResponseType(typeof(IEnumerable<FormDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public IActionResult GetForms()
         {
-            if (!IsAccessValid()) return Ok(Enumerable.Empty<FormDto>());
+            if (!IsAccessValid())
+                return Unauthorized();
 
             return Ok(ZapierFormService.GetAll());
         }


### PR DESCRIPTION
Current PR handles invalid access to the API as `Unauthorized`