### PR TITLE
Handle Shopify installation requests

### DIFF
--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Configuration/AppSettings.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Configuration/AppSettings.cs
@@ -8,6 +8,8 @@
 
         public string SemrushClientSecret { get; set; }
 
+        public string ShopifyClientId { get; set; }
+
         public string ShopifyClientSecret { get; set; }
 
         public string GoogleClientSecret { get; set; }

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Models/ShopifyRequest.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Models/ShopifyRequest.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.AspNetCore.Http;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Umbraco.Cms.Integrations.OAuthProxy.Models
+{
+    public class ShopifyRequest
+    {
+        private readonly IQueryCollection _collection;
+
+        public ShopifyRequest(IQueryCollection collection) => _collection = collection;
+
+        public string Code => _collection["code"];
+
+        public string Shop => _collection["shop"];
+
+        public string Hmac => _collection["hmac"];
+
+        public string Host => _collection["host"];
+
+        public string Timestamp => _collection["timestamp"];
+
+        public bool IsInstallationRequestFlow => !string.IsNullOrEmpty(Shop) && !string.IsNullOrEmpty(Hmac) && string.IsNullOrEmpty(Code);
+
+        public bool IsInstallationRequestFlowWithCode => !string.IsNullOrEmpty(Shop) && !string.IsNullOrEmpty(Hmac) && !string.IsNullOrEmpty(Code);
+
+        public string GetHmacBody()
+        {
+            var dict = _collection
+                .ToDictionary(x => x.Key, x => x.Value)
+                .Where(p => p.Key != "hmac")
+                .OrderBy(p => p.Key);
+            var sb = new StringBuilder();
+            foreach (var kvp in dict)
+            {
+                if (dict.First().Key != kvp.Key)
+                {
+                    sb.Append("&");
+                }
+                sb.Append($"{kvp.Key}={kvp.Value}");
+            }
+
+            return sb.ToString();
+        }
+
+        public string GetHmacValue(string secretKey, string body)
+        {
+            using HMACSHA256 hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secretKey));
+
+            var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(body));
+            StringBuilder hex = new StringBuilder(hash.Length * 2);
+            foreach (byte b in hash)
+            {
+                hex.AppendFormat("{0:x2}", b);
+            }
+            return hex.ToString();
+        }
+
+        public bool IsShopValid() => Shop.Contains("myshopify.com");
+
+    }
+}

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Pages/Shopify.cshtml.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Pages/Shopify.cshtml.cs
@@ -1,14 +1,93 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Umbraco.Cms.Integrations.OAuthProxy.Configuration;
+using Umbraco.Cms.Integrations.OAuthProxy.Models;
 
 namespace Umbraco.Cms.Integrations.OAuthProxy.Pages
 {
     public class ShopifyModel : PageModel
     {
+        private readonly AppSettings _appSettings;
+        private readonly IHttpClientFactory _httpClientFactory;
+
         public string AuthorizationCode { get; set; }
 
-        public void OnGet()
+        public ShopifyModel(IOptions<AppSettings> options, IHttpClientFactory httpClientFactory)
         {
+            _appSettings = options.Value;
+            _httpClientFactory = httpClientFactory;
+        }
+
+        public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+            var shopifyRequest = new ShopifyRequest(Request.Query);
+            // check if this is an installation request flow.
+            if (shopifyRequest.IsInstallationRequestFlow)
+            {
+                var hmacBody = shopifyRequest.GetHmacBody();
+                var hmacValue = shopifyRequest.GetHmacValue(_appSettings.ShopifyClientSecret, hmacBody);
+
+                // verify shop name and HMAC string.
+                if (!shopifyRequest.IsShopValid()
+                    || !shopifyRequest.Hmac.Equals(hmacValue))
+                {
+                    context.Result = new BadRequestObjectResult("Installation verification failed.");
+                    return;
+                }
+
+                var url = string.Format("https://{0}/admin/oauth/authorize?client_id={1}&scope={2}&redirect_uri={3}",
+                        shopifyRequest.Shop,
+                        _appSettings.ShopifyClientId,
+                        "read_products",
+                        $"{Request.Host.Value}/oauth/shopify");
+                context.Result = new RedirectResult(url, true);
+                return;
+            }
+
+            await next();
+        }
+
+        public async Task<IActionResult> OnGetAsync()
+        {
+            var shopifyRequest = new ShopifyRequest(Request.Query);
+            if (shopifyRequest.IsInstallationRequestFlowWithCode)
+            {
+                var hmacBody = shopifyRequest.GetHmacBody();
+                var hmacValue = shopifyRequest.GetHmacValue(_appSettings.ShopifyClientSecret, hmacBody);
+
+                // verify shop name and HMAC string.
+                if (!shopifyRequest.IsShopValid()
+                    || !shopifyRequest.Hmac.Equals(hmacValue))
+                {
+                    return BadRequest("Installation verification failed.");
+                }
+
+                // retrieve access token
+                var client = _httpClientFactory.CreateClient();
+                client.BaseAddress = new Uri($"https://{shopifyRequest.Shop}");
+
+                var requestUri = string.Format("/admin/oauth/access_token?client_id={0}&client_secret={1}&code={2}",
+                    _appSettings.ShopifyClientId,
+                    _appSettings.ShopifyClientSecret,
+                    shopifyRequest.Code);
+                var response = await client.PostAsync(requestUri, new StringContent(string.Empty));
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return BadRequest("Could not retrieve the access token.");
+                }
+
+                return Redirect($"https://{shopifyRequest.Shop}");
+            }
+
             AuthorizationCode = Request.Query["code"];
+
+            return Page();
         }
     }
 }

--- a/src/Umbraco.Cms.Integrations.OAuthProxy/appsettings.Development.json
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/appsettings.Development.json
@@ -11,6 +11,7 @@
     "HubspotClientSecret": "",
     "HubspotFormsClientSecret": "",
     "SemrushClientSecret": "",
+    "ShopifyClientId": "",
     "ShopifyClientSecret": "",
     "GoogleClientSecret": "" 
   }


### PR DESCRIPTION
Current PR adds additional changes to the Shopify dedicated page handling OAuth requests, as part of the application submission process and to address the latest feedback from Shopify's app approval team.

We would need to address the following issue reported:
![image](https://github.com/user-attachments/assets/f433f3e8-8d1d-437e-9ca4-88020f78488f)

The shop admin tries to install the Umbraco application on the store and should follow the path described [here](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/authorization-code-grant#step-1-verify-the-installation-request). Instead, the users remain on the proxy page hosted by us, which is not allowed by Shopify.
![image](https://github.com/user-attachments/assets/24c35767-4365-44a8-9e28-e3f582bf5f67)

To address this, I've followed the steps detailed in the [document](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/authorization-code-grant#step-1-verify-the-installation-request) and extended the functionality of the page accordingly.
- First, I identify that there is an installation request coming from Shopify right before the page execution based on the existence of the `shop` and `hmac` query string parameters.
- If parameters are missing, then we skip the validation - this happens when users authenticate from the Umbraco backoffice, and only the `code` parameter is sent.
- Next step is to validate the shop name and the value of the `hmac` parameter. Details on the validation process [here](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/authorization-code-grant#remove-the-hmac-parameter-from-the-query-string) - I am basically using the client secret as hashing key, and the string body is represented by a string of query params, without the `hmac` parameter.
- If validations are passed, I trigger an authorization flow which will return an authorization code. At this stage, the same shop/hmac validation will occur, a brief validation that the authorization code is valid, and will redirect the user back to the shop's admin.
