### PR TITLE
Include scheme with redirect uri

### DIFF
--- a/src/Umbraco.Cms.Integrations.OAuthProxy/Pages/Shopify.cshtml.cs
+++ b/src/Umbraco.Cms.Integrations.OAuthProxy/Pages/Shopify.cshtml.cs
@@ -44,7 +44,7 @@ namespace Umbraco.Cms.Integrations.OAuthProxy.Pages
                         shopifyRequest.Shop,
                         _appSettings.ShopifyClientId,
                         "read_products",
-                        $"{Request.Host.Value}/oauth/shopify");
+                        $"{Request.Scheme}://{Request.Host.Value}/oauth/shopify");
                 context.Result = new RedirectResult(url, true);
                 return;
             }


### PR DESCRIPTION
With this PR I am including the request scheme with the redirect URI, following the latest feedback from Shopify, that specify that an error has occurred during authorization.

The message specified that `Oauth error invalid_request: The redirect_uri is not whitelisted`, but the settings of the app are correct, except the scheme.