### PR TITLE
Fix ActiveCampaign workflow retry

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/ActiveCampaignContactsWorkflow.cs
+++ b/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/ActiveCampaignContactsWorkflow.cs
@@ -60,9 +60,30 @@ public class ActiveCampaignContactsWorkflow : WorkflowType
 		{
 			var mappings = JsonSerializer.Deserialize<List<ContactMappingDto>>(ContactMappings);
 
-			var email = context.Record.RecordFields[Guid.Parse(mappings.First(p => p.ContactField == "email").FormField.Id)]
-				.ValuesAsString();
+			string email = string.Empty;
+			var mappedEmailGuid = Guid.Parse(mappings.First(p => p.ContactField == "email").FormField.Id);
 
+			if (context.Record.RecordFields.ContainsKey(mappedEmailGuid) == false)
+			{
+				// Get email when retrying workflow
+				var matchedField = context.Record.RecordFields.FirstOrDefault(x => x.Value.FieldId == mappedEmailGuid);
+				if (matchedField.Value != null)
+				{
+					email = matchedField.Value.ValuesAsString();
+				}
+			}
+			else
+			{
+				// Get email when executing workflow for the first time
+				email = context.Record.RecordFields[mappedEmailGuid]
+					.ValuesAsString();
+			}
+
+			if (string.IsNullOrEmpty(email))
+			{
+				_logger.LogWarning("Email not set for the record!");
+				return WorkflowExecutionStatus.Failed;
+			}
 			// Check if contact exists.
 			var contacts = await _contactService.Get(email);
 


### PR DESCRIPTION
We encountered an issue when retrying the workflow from the ActiveCampaign repo. There seems to be a key mismatch when retrying since the `context.Record.RecordFields` id's change when retrying. This prevents the workflow from running so you can never retry sending an entry to ActiveCampaign.