### PR TITLE
Update the ReadMappingsValue function to work on workflow retries.

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/Umbraco.Forms.Integrations.Crm.ActiveCampaign.csproj
+++ b/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign/Umbraco.Forms.Integrations.Crm.ActiveCampaign.csproj
@@ -13,7 +13,7 @@
 		<PackageIconUrl></PackageIconUrl>
 		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Forms.Integrations/tree/main-v10/src/Umbraco.Forms.Integrations.Crm.ActiveCampaign</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Forms.Integrations</RepositoryUrl>
-		<Version>2.0.0</Version>
+		<Version>2.0.1</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>


### PR DESCRIPTION
Current PR extends pull request #109 , by updating the `ReadMappingValue` method with the initial code. On workflow retries, the method was throwing an exception when populating the properties of the request DTO.