### PR TITLE
Include HubSpot client assets with package

### DIFF
--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Client/config.outputPath.js
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Client/config.outputPath.js
@@ -1,0 +1,1 @@
+export const outputPath = '../wwwroot'

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Client/public/umbraco-package.json
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Client/public/umbraco-package.json
@@ -1,7 +1,7 @@
 {
     "id": "Umbraco.Integrations.Integrations.Crm.HubSpot",
     "name": "Umbraco Integrations Integrations: CRM - HubSpot",
-    "version": "8.0.0",
+    "version": "8.0.1",
     "extensions": [
       {
         "name": "Umbraco EntryPoint",

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/Umbraco.Forms.Integrations.Crm.Hubspot.csproj
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/Umbraco.Forms.Integrations.Crm.Hubspot.csproj
@@ -15,9 +15,9 @@
 		<Title>Umbraco Forms Integrations: CRM - Hubspot</Title>
 		<Description>An extension for Umbraco Forms to add support for submitting data to Hubspot</Description>
 		<PackageIconUrl></PackageIconUrl>
-		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Forms.Integrations/tree/main-v16/src/Umbraco.Forms.Integrations.Crm.Hubspot</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/umbraco/Umbraco.Forms.Integrations/tree/main-v17/src/Umbraco.Forms.Integrations.Crm.Hubspot</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/umbraco/Umbraco.Forms.Integrations</RepositoryUrl>
-		<Version>8.0.0</Version>
+		<Version>8.0.1</Version>
 		<Authors>Umbraco HQ</Authors>
 		<Company>Umbraco</Company>
 		<PackageTags>Umbraco;Umbraco-Marketplace</PackageTags>
@@ -49,4 +49,14 @@
     <ItemGroup>
         <Content Include="wwwroot\**" Pack="true" />
     </ItemGroup>
+
+	<!-- Build client assets using NPM -->
+	<Import Project="build\Microsoft.AspNetCore.ClientAssets.targets" />
+	<PropertyGroup>
+		<!-- Use this to (temporarily) disable building client assets, e.g. to start the project and generate updated API models -->
+		<ShouldRunClientAssetsBuild>true</ShouldRunClientAssetsBuild>
+	</PropertyGroup>
+	<Target Name="ClientAssetsBuildOutputPath" BeforeTargets="ClientAssetsBuild">
+		<WriteLinesToFile File="Client\config.outputPath.js" Lines="export const outputPath = '../wwwroot';" Overwrite="true" />
+	</Target>
 </Project>

--- a/src/Umbraco.Forms.Integrations.Crm.Hubspot/build/Microsoft.AspNetCore.ClientAssets.targets
+++ b/src/Umbraco.Forms.Integrations.Crm.Hubspot/build/Microsoft.AspNetCore.ClientAssets.targets
@@ -1,0 +1,61 @@
+<Project>
+	<!--
+        Copied from: https://github.com/aspnet/AspLabs/blob/main/src/ClientAssets/Microsoft.AspNetCore.ClientAssets/build/netstandard2.0/Microsoft.AspNetCore.ClientAssets.targets
+
+        More information:
+        - https://devblogs.microsoft.com/dotnet/build-client-web-assets-for-your-razor-class-library/
+        - https://github.com/dotnet/aspnetcore/issues/38445
+    -->
+	<PropertyGroup>
+		<ClientAssetsDirectory Condition="'$(ClientAssetsDirectory)' == ''">Client\</ClientAssetsDirectory>
+		<ClientAssetsRestoreInputs Condition="'$(ClientAssetsRestoreInputs)' == ''">$(ClientAssetsDirectory)\package-lock.json;$(ClientAssetsDirectory)\package.json</ClientAssetsRestoreInputs>
+		<ClientAssetsRestoreOutputs Condition="'$(ClientAssetsRestoreOutputs)' == ''">$(ClientAssetsDirectory)node_modules\.package-lock.json</ClientAssetsRestoreOutputs>
+		<ClientAssetsRestoreCommand Condition="'$(ClientAssetsRestoreCommand)' == ''">npm ci --no-fund --no-audit --prefer-offline</ClientAssetsRestoreCommand>
+		<ClientAssetsBuildCommand Condition="'$(ClientAssetsBuildCommand)' == ''">npm run build</ClientAssetsBuildCommand>
+
+		<!-- Include project file to pick up changes in the above values -->
+		<ClientAssetsRestoreInputs>$(MSBuildProjectFile);$(ClientAssetsRestoreInputs)</ClientAssetsRestoreInputs>
+		<!-- Run restore only once for multi targeting builds -->
+		<ClientAssetsRestoreBeforeTargets Condition="'$(TargetFramework)' == ''">DispatchToInnerBuilds</ClientAssetsRestoreBeforeTargets>
+		<!-- Allow multitargeting projects to choose the target framework in which they run by setting this value to true only for a given target framework -->
+		<ShouldRunClientAssetsBuild Condition="'$(ShouldRunClientAssetsBuild)' == ''">true</ShouldRunClientAssetsBuild>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ClientAssetsInputs Include="$(ClientAssetsDirectory)**" Exclude="$(DefaultItemExcludes)" />
+	</ItemGroup>
+
+	<Target Name="ClientAssetsRestore" BeforeTargets="$(ClientAssetsRestoreBeforeTargets)" Inputs="$(ClientAssetsRestoreInputs)" Outputs="$(ClientAssetsRestoreOutputs)">
+		<Message Text="Restoring NPM packages" Importance="high" />
+		<Exec Command="$(ClientAssetsRestoreCommand)" WorkingDirectory="$(ClientAssetsDirectory)"/>
+	</Target>
+
+	<Target Name="ClientAssetsBuild" Condition="'$(ShouldRunClientAssetsBuild)' == 'true'" DependsOnTargets="ClientAssetsRestore" BeforeTargets="AssignTargetPaths" Inputs="@(ClientAssetsInputs)" Outputs="$(IntermediateOutputPath)clientassetsbuild.complete.txt">
+		<PropertyGroup>
+			<_ClientAssetsOutputFullPath>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)clientassets'))</_ClientAssetsOutputFullPath>
+		</PropertyGroup>
+
+		<Message Text="Executing NPM build script" Importance="High" />
+
+		<MakeDir Directories="$(_ClientAssetsOutputFullPath)" />
+		<Exec Command="$(ClientAssetsBuildCommand)" WorkingDirectory="$(ClientAssetsDirectory)" />
+
+		<ItemGroup>
+			<_ClientAssetsBuildOutput Include="$(IntermediateOutputPath)clientassets\**"></_ClientAssetsBuildOutput>
+		</ItemGroup>
+
+		<WriteLinesToFile File="$(IntermediateOutputPath)clientassetsbuild.complete.txt" Lines="@(_ClientAssetsBuildOutput)" />
+	</Target>
+
+	<Target Name="DefineClientAssets" AfterTargets="ClientAssetsBuild" DependsOnTargets="ResolveStaticWebAssetsConfiguration">
+		<ItemGroup>
+			<FileWrites Include="@(_ClientAssetsBuildOutput)" />
+			<FileWrites Include="$(IntermediateOutputPath)clientassetsbuild.complete.txt" />
+		</ItemGroup>
+
+		<DefineStaticWebAssets CandidateAssets="@(_ClientAssetsBuildOutput)" SourceId="$(PackageId)" SourceType="Computed" ContentRoot="$(_ClientAssetsOutputFullPath)" BasePath="$(StaticWebAssetBasePath)">
+			<Output TaskParameter="Assets" ItemName="StaticWebAsset" />
+		</DefineStaticWebAssets>
+	</Target>
+
+</Project>


### PR DESCRIPTION
Current PR fixes issue [#82] (https://github.com/umbraco/Umbraco.Integrations.Issues/issues/18) for the Umbraco Forms HubSpot Integration, that has the client assets missing form the NuGet package.